### PR TITLE
Add a dev container for Soroban development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/rust:latest
+
+USER vscode
+RUN cargo install --locked soroban-cli
+RUN rustup target add wasm32-unknown-unknown
+
+# The following should be run at a project level:
+# soroban config network add testnet --rpc-url "http://host.docker.internal:8000/soroban/rpc" --network-passphrase "Test SDF Network ; September 2015"
+# soroban keys generate alice --network testnet

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Soroban",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer",
+				"vscodevim.vim"
+			],
+			"settings": {
+				"extensions.ignoreRecommendations": true, // don't show recommendations for extensions
+				"terminal.integrated.copyOnSelection": true
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add a [VSCode dev container](https://code.visualstudio.com/docs/devcontainers/containers) for Soroban development.

This simply takes the Rust dev container from Microsoft and installs `soroban-cli` and the appropriate wasm target.

If the [quickstart Docker image](https://github.com/stellar/quickstart) is run outside the container, its RPC endpoint is available as `http://host.docker.internal:8000/soroban/rpc`.