### PR TITLE
add husky commit hooks to do housekeeping

### DIFF
--- a/solarkraft/.husky/pre-commit
+++ b/solarkraft/.husky/pre-commit
@@ -1,2 +1,2 @@
 cd solarkraft
-npm test
+npm run lint && npm run license

--- a/solarkraft/.husky/pre-commit
+++ b/solarkraft/.husky/pre-commit
@@ -1,0 +1,2 @@
+cd solarkraft
+npm test

--- a/solarkraft/eslint.config.js
+++ b/solarkraft/eslint.config.js
@@ -1,3 +1,7 @@
+/**
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
 // @ts-check
 
 import eslint from '@eslint/js';

--- a/solarkraft/package-lock.json
+++ b/solarkraft/package-lock.json
@@ -26,6 +26,7 @@
         "copyfiles": "^2.4.1",
         "eslint": "^8.57.0",
         "genversion": "^3.2.0",
+        "husky": "^9.0.11",
         "mocha": "^10.3.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5",
@@ -1582,6 +1583,21 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {
@@ -4132,6 +4148,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "husky": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true
     },
     "ignore": {

--- a/solarkraft/package.json
+++ b/solarkraft/package.json
@@ -35,7 +35,8 @@
     "license": "source-licenser --config-file licenser-config.yaml .",
     "snapshot": "git archive --format=tar.gz -o solarkraft-`git rev-parse --short HEAD`.tar.gz --prefix=solarkraft/ HEAD",
     "test": "mocha --loader=ts-node/esm test/**/*.test.ts",
-    "lint": "eslint src test"
+    "lint": "eslint src test",
+    "prepare": "husky"
   },
   "dependencies": {
     "@sweet-monads/either": "^3.3.1",
@@ -52,6 +53,7 @@
     "copyfiles": "^2.4.1",
     "eslint": "^8.57.0",
     "genversion": "^3.2.0",
+    "husky": "^9.0.11",
     "mocha": "^10.3.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",

--- a/solarkraft/package.json
+++ b/solarkraft/package.json
@@ -33,10 +33,10 @@
     "compile": "genversion -e src/version.ts && tsc",
     "e2e": "./test/e2e/run-tests.sh",
     "license": "source-licenser --config-file licenser-config.yaml .",
-    "snapshot": "git archive --format=tar.gz -o solarkraft-`git rev-parse --short HEAD`.tar.gz --prefix=solarkraft/ HEAD",
-    "test": "mocha --loader=ts-node/esm test/**/*.test.ts",
     "lint": "eslint src test",
-    "prepare": "cd .. && husky solarkraft/.husky"
+    "prepare": "cd .. && husky solarkraft/.husky",
+    "snapshot": "git archive --format=tar.gz -o solarkraft-`git rev-parse --short HEAD`.tar.gz --prefix=solarkraft/ HEAD",
+    "test": "mocha --loader=ts-node/esm test/**/*.test.ts"
   },
   "dependencies": {
     "@sweet-monads/either": "^3.3.1",

--- a/solarkraft/package.json
+++ b/solarkraft/package.json
@@ -36,7 +36,7 @@
     "snapshot": "git archive --format=tar.gz -o solarkraft-`git rev-parse --short HEAD`.tar.gz --prefix=solarkraft/ HEAD",
     "test": "mocha --loader=ts-node/esm test/**/*.test.ts",
     "lint": "eslint src test",
-    "prepare": "husky"
+    "prepare": "cd .. && husky solarkraft/.husky"
   },
   "dependencies": {
     "@sweet-monads/either": "^3.3.1",


### PR DESCRIPTION
This PR add [husky](https://typicode.github.io/husky/) commit hooks to do the following on `git commit`:
 - check that `eslint` passes
 - update the license boilerplate, that is, add the license header to the source files
 - once we have #22 merged, it will also reformat the code.

This is all done, so we don't have to wait for Github actions to fail on these housekeeping tests. 