### PR TITLE
Add mock CLI commands

### DIFF
--- a/solarkraft/src/fetch.ts
+++ b/solarkraft/src/fetch.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
+/**
+ * Fetch transactions from the ledger
+ * @param args the arguments parsed by yargs
+ */
+export function fetch(args: any) {
+    console.log(
+        `*** WARNING: THIS IS A MOCK. NOTHING IS IMPLEMENTED YET. ***\n`
+    )
+    console.log(`Target contract: ${args.id}...`)
+    console.log(`Fetching fresh transactions from: ${args.rpc}...`)
+    // read the latest height cached from the latest invocation of fetch
+    const cachedHeight = 1000
+    // fetch the actual height from the RPC endpoint
+    const currentHeight = 12345
+    let startHeight =
+        args.height < 0 ? currentHeight + args.height : args.height
+    startHeight = Math.max(startHeight, cachedHeight)
+    console.log(`| ledger | cached | start |`)
+    console.log(`| ${currentHeight}  | ${cachedHeight}   | ${startHeight} |\n`)
+    // fetch the transactions that involve that target contract
+    console.log(
+        `TX b6efc58ab03db82b5b2fa44b69ff89b64e54af5e6e5266dbdd70fc57d2dc583e at 51291021`
+    )
+    console.log(
+        `TX d669f322d1011a3726301535f5451ef4398d40ad150b79845fb9a5fc781092cf at 51291024`
+    )
+    console.log(
+        `TX cf96fc2bb266912f8063c6091a70a680498bbe41e71132814f765186926e4f80 at 51291018`
+    )
+}

--- a/solarkraft/src/list.ts
+++ b/solarkraft/src/list.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
+/**
+ * List the transactions fetched from the ledger
+ */
+export function list() {
+    console.log(
+        `*** WARNING: THIS IS A MOCK. NOTHING IS IMPLEMENTED YET. ***\n`
+    )
+
+    console.log(`Verified:`)
+    console.log(
+        `TX d669f322d1011a3726301535f5451ef4398d40ad150b79845fb9a5fc781092cf at 51291024`
+    )
+    console.log(
+        `TX cf96fc2bb266912f8063c6091a70a680498bbe41e71132814f765186926e4f80 at 51291018`
+    )
+    console.log('')
+    console.log(`Unverified:`)
+    console.log(
+        `TX b6efc58ab03db82b5b2fa44b69ff89b64e54af5e6e5266dbdd70fc57d2dc583e at 51291021`
+    )
+}

--- a/solarkraft/src/main.ts
+++ b/solarkraft/src/main.ts
@@ -11,9 +11,9 @@ import { version } from './version.js'
 // The default options present in every command
 const defaultOpts = (yargs: any) =>
     yargs.option('color', {
-      desc: 'color output',
-      type: 'boolean',
-      default: true,
+        desc: 'color output',
+        type: 'boolean',
+        default: true,
     })
 
 // transaction extractor
@@ -21,17 +21,16 @@ const txExtractorCmd = {
     command: ['txs'],
     desc: 'extract transactions',
     builder: (yargs: any) =>
-      defaultOpts(yargs)
-        .option('id', {
-          desc: 'Contract id',
-          type: 'string',
-          default: '123',
+        defaultOpts(yargs).option('id', {
+            desc: 'Contract id',
+            type: 'string',
+            default: '123',
         }),
     handler: onTxExtractor,
 }
 
 // call the transaction extractor here
-function onTxExtractor (args: any) {
+function onTxExtractor(args: any) {
     console.log(`Mock TX Extractor(id: ${args.id})`)
 }
 

--- a/solarkraft/src/main.ts
+++ b/solarkraft/src/main.ts
@@ -7,6 +7,9 @@
 
 import yargs from 'yargs'
 import { version } from './version.js'
+import { fetch } from './fetch.js'
+import { verify } from './verify.js'
+import { list } from './list.js'
 
 // The default options present in every command
 const defaultOpts = (yargs: any) =>
@@ -16,27 +19,56 @@ const defaultOpts = (yargs: any) =>
         default: true,
     })
 
-// transaction extractor
-const txExtractorCmd = {
-    command: ['txs'],
-    desc: 'extract transactions',
+// fetch: transaction extractor
+const fetchCmd = {
+    command: ['fetch'],
+    desc: 'fetch Soroban transactions from Stellar',
     builder: (yargs: any) =>
-        defaultOpts(yargs).option('id', {
-            desc: 'Contract id',
-            type: 'string',
-            default: '123',
-        }),
-    handler: onTxExtractor,
+        defaultOpts(yargs)
+            .option('id', {
+                desc: 'Contract id',
+                type: 'string',
+                default: '123',
+            })
+            .option('rpc', {
+                desc: 'URL of the Stellar RPC',
+                type: 'string',
+                default: 'http://localhost:8000',
+            })
+            .option('height', {
+                desc: 'The height to start with (a negative value -n goes from the latest block - n)',
+                type: 'number',
+                default: -10,
+            }),
+    handler: fetch,
 }
 
-// call the transaction extractor here
-function onTxExtractor(args: any) {
-    console.log(`Mock TX Extractor(id: ${args.id})`)
+// verify: transaction verifier
+const verifyCmd = {
+    command: ['verify'],
+    desc: 'verify a previously fetched transaction',
+    builder: (yargs: any) =>
+        defaultOpts(yargs).option('txHash', {
+            desc: 'Transaction hash',
+            type: 'string',
+            demandOption: true,
+        }),
+    handler: verify,
+}
+
+// list: show the fetched and verified transactions
+const listCmd = {
+    command: ['list'],
+    desc: 'list the fetched and verified transactions',
+    builder: (yargs: any) => defaultOpts(yargs),
+    handler: list,
 }
 
 function main() {
     return yargs(process.argv.slice(2))
-        .command(txExtractorCmd)
+        .command(fetchCmd)
+        .command(verifyCmd)
+        .command(listCmd)
         .demandCommand(1)
         .version(version)
         .strict()

--- a/solarkraft/src/verify.ts
+++ b/solarkraft/src/verify.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
+/**
+ * Verify transactions fetched from the ledger
+ * @param args the arguments parsed by yargs
+ */
+export function verify(args: any) {
+    console.log(
+        `*** WARNING: THIS IS A MOCK. NOTHING IS IMPLEMENTED YET. ***\n`
+    )
+    console.log(`Verifying transaction: ${args.txHash}...`)
+    console.log(`[OK]`)
+}


### PR DESCRIPTION
Closes #25. I have thought a bit about the CLI commands that we would need. Here is the first mock that contains `fetch`, `list`, and `verify`. To check this PR, simply pull it, compile and play with `solarkraft`.