### PR TITLE
Pin devcontainer platform to linux/amd64

### DIFF
--- a/solarkraft/.devcontainer/Dockerfile
+++ b/solarkraft/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+# Force platform to linux/amd64; there is no Z3 release for linux/arm64:
+# https://github.com/Z3Prover/z3/issues/7201
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/typescript-node:20-bookworm

--- a/solarkraft/.devcontainer/devcontainer.json
+++ b/solarkraft/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
 	"name": "Solarkraft",
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:20-bookworm",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
 		"ghcr.io/devcontainers/features/java:1": {},
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},


### PR DESCRIPTION
There are no Z3 binaries for linux/aarch64 for now: https://github.com/Z3Prover/z3/issues/7201

Pin the devcontainer platform to `linux/amd64` to work around it.