### PR TITLE
Add tlaplus VSCode plugin to dev container

### DIFF
--- a/solarkraft/.devcontainer/devcontainer.json
+++ b/solarkraft/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"alygin.vscode-tlaplus",
 				"vscodevim.vim"
 			],
 			"settings": {


### PR DESCRIPTION
Add the [tlaplus VSCode plugin](https://marketplace.visualstudio.com/items?itemName=alygin.vscode-tlaplus) to the dev container spec.

This will install the plugin automatically when opening the dev container.