### PR TITLE
Read ITF in monitor executor

### DIFF
--- a/solarkraft/src/instrument.ts
+++ b/solarkraft/src/instrument.ts
@@ -2,7 +2,6 @@
  * @license
  * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
  */
-// TODO(#38): Replace stubs with ITF
 type Value = { type: string; value: any }
 type Binding = { name: string; type: string; value: any }
 type State = Binding[]
@@ -11,6 +10,27 @@ type Transaction = {
     functionArgs: Value[]
     env: { timestamp: number }
     error: string
+}
+
+/**
+ * Return a `State` from an ITF JSON object.
+ * @param itf ITF JSON object, see https://apalache.informal.systems/docs/adr/015adr-trace.html
+ * @returns `State`
+ */
+export function stateFromItf(itf: any): State {
+    // const vars = itf['vars'] // e.g., [ "is_initialized", "last_error" ]
+    const varTypes = itf['#meta']['varTypes'] // e.g., { "is_initialized": "Bool", "last_error": "Str" }
+    const initState = itf['states'][0] // e.g., [ { "is_initialized": false, "last_error": "" }, state1, ... ]
+    delete initState['#meta']
+
+    const state = Object.entries(initState)
+        .filter(([name]) => name != '#meta')
+        .map(([name, value]) => ({
+            name: name,
+            value: value,
+            type: 'Tla' + varTypes[name],
+        }))
+    return state
 }
 
 /**

--- a/solarkraft/src/main.ts
+++ b/solarkraft/src/main.ts
@@ -58,6 +58,12 @@ const verifyCmd = {
                 desc: 'Monitor to check against',
                 type: 'string',
                 demandOption: true,
+            })
+            .option('state', {
+                // TODO(#38): read state from fetcher output
+                desc: 'ITF file encoding ledger state',
+                type: 'string',
+                demandOption: true,
             }),
     handler: verify,
 }

--- a/solarkraft/test/e2e/verify.test.ts
+++ b/solarkraft/test/e2e/verify.test.ts
@@ -6,7 +6,9 @@ import { spawn } from 'nexpect'
 
 describe('verify', () => {
     it('fails on missing file', function (done) {
-        spawn('solarkraft verify --txHash mimimi --monitor doesnotexist')
+        spawn(
+            'solarkraft verify --txHash mimimi --monitor doesnotexist --state test/e2e/tla/timelock_state.itf.json'
+        )
             .wait('The monitor file doesnotexist does not exist.')
             .expect('[Error]')
             .run(done)
@@ -15,7 +17,7 @@ describe('verify', () => {
     it('reports success on okay monitor', function (done) {
         this.timeout(50000)
         spawn(
-            'solarkraft verify --txHash mimimi --monitor test/e2e/tla/timelock_mon1_instrumented_okay.tla'
+            'solarkraft verify --txHash mimimi --monitor test/e2e/tla/timelock_mon1_instrumented_okay.tla --state test/e2e/tla/timelock_state.itf.json'
         )
             .wait('[OK]')
             .run(done)
@@ -24,7 +26,7 @@ describe('verify', () => {
     it('reports failure on deadlocking monitor', function (done) {
         this.timeout(50000)
         spawn(
-            'solarkraft verify --txHash mimimi --monitor test/e2e/tla/timelock_mon1_instrumented_fail.tla'
+            'solarkraft verify --txHash mimimi --monitor test/e2e/tla/timelock_mon1_instrumented_fail.tla --state test/e2e/tla/timelock_state.itf.json'
         )
             .wait('Monitor is unable to reproduce the transaction')
             .expect('[Fail]')


### PR DESCRIPTION
Remove hardcoded state in monitor executor and instead read state from ITF.

Introduces a transitional `--state` argument to `verify` that we can replace with convention when the fetcher writes ITF.

Closes #42 