### PR TITLE
Add a script to populate the Setter contract

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,3 +65,5 @@ jobs:
         run: cd ContractExamples && cargo build --verbose
       - name: unit tests
         run: cd ContractExamples && cargo test --verbose
+      - name: populating setter
+        run: cd ContractExamples && ./scripts/setter-populate.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,17 +60,20 @@ jobs:
       - uses: stellar/binaries@v22
         with:
           name: soroban-cli
-          version: '21.0.0-preview.1'
+          version: '20.0.0-rc.4.1'
+          # version 21 is not available in stellar/binaries yet
+          #version: '21.0.0-preview.1'
       - name: build
         run: cd ContractExamples && cargo build --verbose
       - name: unit tests
         run: cd ContractExamples && cargo test --verbose
-      - name: populating Setter
-        run: |
-          soroban network add \
-            --global testnet \
-            --rpc-url https://soroban-testnet.stellar.org:443 \
-            --network-passphrase "Test SDF Network ; September 2015"
-          soroban keys generate --global alice --network testnet
-          cd ContractExamples
-          ./scripts/setter-populate.sh
+      # v21 is not available in stellar/binaries yet
+      #- name: populating Setter
+      #  run: |
+      #    soroban network add \
+      #      --global testnet \
+      #      --rpc-url https://soroban-testnet.stellar.org:443 \
+      #      --network-passphrase "Test SDF Network ; September 2015"
+      #    soroban keys generate --global alice --network testnet
+      #    cd ContractExamples
+      #    ./scripts/setter-populate.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: rustup target add wasm32-unknown-unknown
-      - uses: stellar/binaries@v16
+      - uses: stellar/binaries@v22
         with:
           name: soroban-cli
-          version: "21.0.0-preview.1"
+          version: '21.0.0-preview.1'
       - name: build
         run: cd ContractExamples && cargo build --verbose
       - name: unit tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: stellar/binaries@v16
         with:
           name: soroban-cli
-          version: 0.8.7
+          version: "21.0.0-preview.1"
       - name: build
         run: cd ContractExamples && cargo build --verbose
       - name: unit tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,5 +65,12 @@ jobs:
         run: cd ContractExamples && cargo build --verbose
       - name: unit tests
         run: cd ContractExamples && cargo test --verbose
-      - name: populating setter
-        run: cd ContractExamples && ./scripts/setter-populate.sh
+      - name: populating Setter
+        run: |
+          soroban network add \
+            --global testnet \
+            --rpc-url https://soroban-testnet.stellar.org:443 \
+            --network-passphrase "Test SDF Network ; September 2015"
+          soroban keys generate --global alice --network testnet
+          cd ContractExamples
+          ./scripts/setter-populate.sh

--- a/ContractExamples/contracts/setter/README.md
+++ b/ContractExamples/contracts/setter/README.md
@@ -4,7 +4,7 @@ fetcher.
 
 ## How to use
 
- 1. Make sure that you have installed Soroban by following the [Getting Started]
+ 1. Make sure that you have installed Soroban by following the [Getting Started][]
  guide.
 
  1. Deploy the setter contract:

--- a/ContractExamples/contracts/setter/src/lib.rs
+++ b/ContractExamples/contracts/setter/src/lib.rs
@@ -1,4 +1,12 @@
 #![no_std]
+/**
+ * A test contract for better understanding of the ledger layout of Soroban contracts.
+ *
+ * Igor Konnov, 2024.
+ *
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
 
 use soroban_sdk::{contract, contractimpl, contracttype, log, symbol_short, vec, Address, Bytes, BytesN, Env, Map, Symbol, Vec};
 

--- a/ContractExamples/contracts/setter/src/test.rs
+++ b/ContractExamples/contracts/setter/src/test.rs
@@ -1,4 +1,12 @@
 #![cfg(test)]
+/**
+ * Unit tests for Setter.
+ *
+ * Igor Konnov, 2024.
+ *
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
 
 use super::*;
 use soroban_sdk::{

--- a/ContractExamples/scripts/setter-populate.sh
+++ b/ContractExamples/scripts/setter-populate.sh
@@ -14,39 +14,46 @@ dir=$(cd `dirname $0`; pwd -P)
 
 cd ${dir}/..
 
+NET=testnet
+(soroban network ls | grep -q $NET) || (echo "add testnet via soroban network"; exit 1)
+
+ACCOUNT=alice
+soroban keys address $ACCOUNT || (echo "add the account $ALICE via soroban keys generate"; exit 1)
+
+
 set -x
 
 soroban contract build
 soroban contract deploy --wasm target/wasm32-unknown-unknown/release/setter.wasm \
-      --source alice --network testnet | tee >.setter.id
+      --source $ACCOUNT --network $NET | tee >.setter.id
 
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_bool --v true
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_u32 --v 42
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
-      -- set_i32 --v -42
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+      -- set_i32 --v '-42'
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_u64 --v 42
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
-      -- set_i64 --v -42
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+      -- set_i64 --v '-42'
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_u128 --v 42
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
-      -- set_i128 --v -42
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+      -- set_i128 --v '-42'
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_sym --v hello
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_bytes --v beef
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_bytes32 --v beef0123456789beef0123456789beef0123456789ab
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_vec --v '[ 1, -2, 3 ]'
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_map --v '{ "2": 3, "4": 5 }'
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_address --v GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_my_struct --v '{ "a": 1, "b": "-100" }'
-soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_my_enum --v A

--- a/ContractExamples/scripts/setter-populate.sh
+++ b/ContractExamples/scripts/setter-populate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Deploy the setter contract and populate its state with data.
+#
+# Igor Konnov, 2024
+#
+# @license
+# [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+
+
+set -e
+
+dir=$(cd `dirname $0`; pwd -P)
+
+cd ${dir}/..
+
+set -x
+
+soroban contract build
+soroban contract deploy --wasm target/wasm32-unknown-unknown/release/setter.wasm \
+      --source alice --network testnet | tee >.setter.id
+
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_bool --v true
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_u32 --v 42
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_i32 --v -42
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_u64 --v 42
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_i64 --v -42
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_u128 --v 42
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_i128 --v -42
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_sym --v hello
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_bytes --v beef
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_bytes32 --v beef0123456789beef0123456789beef0123456789ab
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_vec --v '[ 1, -2, 3 ]'
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_map --v '{ "2": 3, "4": 5 }'
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_address --v GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_my_struct --v '{ "a": 1, "b": "-100" }'
+soroban contract invoke --id $(cat .setter.id) --source alice --network testnet \
+      -- set_my_enum --v A


### PR DESCRIPTION
This PR adds a bash script for populating the `Setter` contract with data, so we can use it in our integration tests.