### PR TITLE
working fetcher CLI

### DIFF
--- a/solarkraft/src/fetch.ts
+++ b/solarkraft/src/fetch.ts
@@ -11,7 +11,11 @@
 
 import { Horizon } from '@stellar/stellar-sdk'
 import { extractContractCall } from './fetcher/callDecoder.js'
-import { loadFetcherState, saveContractCallEntry, saveFetcherState } from './fetcher/storage.js'
+import {
+    loadFetcherState,
+    saveContractCallEntry,
+    saveFetcherState,
+} from './fetcher/storage.js'
 
 // how often to query for the latest synchronized height
 const HEIGHT_FETCHING_PERIOD = 100
@@ -40,7 +44,7 @@ export async function fetch(args: any) {
     }
 
     console.log(`Fetching fresh transactions from: ${args.rpc}...`)
-    
+
     console.log(`Fetching the ledger for ${lastHeight}`)
     const response = await server.ledgers().ledger(lastHeight).call()
     const startCursor = (response as any).paging_token
@@ -65,8 +69,10 @@ export async function fetch(args: any) {
         .stream({
             onmessage: async (msg: any) => {
                 if (msg.transaction_successful) {
-                    const callEntryMaybe =
-                        await extractContractCall(msg, (id) => contractId === id)
+                    const callEntryMaybe = await extractContractCall(
+                        msg,
+                        (id) => contractId === id
+                    )
                     if (callEntryMaybe.isJust()) {
                         const entry = callEntryMaybe.value
                         console.log(`+ save: ${entry.height}`)
@@ -83,7 +89,13 @@ export async function fetch(args: any) {
                     console.log(`= at: ${lastHeight}`)
                     // load and save the state, other fetchers may work concurrently
                     fetcherState = loadFetcherState(args.home)
-                    fetcherState = { ...fetcherState, heights: fetcherState.heights.set(contractId, lastHeight) }
+                    fetcherState = {
+                        ...fetcherState,
+                        heights: fetcherState.heights.set(
+                            contractId,
+                            lastHeight
+                        ),
+                    }
                     saveFetcherState(args.home, fetcherState)
                 }
             },

--- a/solarkraft/src/fetch.ts
+++ b/solarkraft/src/fetch.ts
@@ -35,8 +35,8 @@ export async function fetch(args: any) {
     console.log(`Last cached height: ${cachedHeight}`)
     if (args.height < 0) {
         // how to fetch the latest height?
-        console.log('not implemented yet, starting with 0')
-        lastHeight = 0
+        console.log(`not implemented yet, starting with ${cachedHeight}`)
+        lastHeight = cachedHeight
     } else if (args.height === 0) {
         lastHeight = cachedHeight
     } else {
@@ -82,12 +82,14 @@ export async function fetch(args: any) {
 
                 nEvents++
                 if (nEvents % HEIGHT_FETCHING_PERIOD === 0) {
-                    // Fetch the height of the current message.
+                    // Fetch the height of the current message and persist it for the future runs.
                     // Note that messages may come slightly out of order, so the heights are not precise.
                     const tx = await msg.transaction()
                     lastHeight = Math.max(lastHeight, tx.ledger_attr)
                     console.log(`= at: ${lastHeight}`)
-                    // load and save the state, other fetchers may work concurrently
+                    // Load and save the state. Other fetchers may work concurrently,
+                    // so there is a possibility of overwriting an updated height.
+                    // This will result in a fetcher doing additional work on the next run.
                     fetcherState = loadFetcherState(args.home)
                     fetcherState = {
                         ...fetcherState,

--- a/solarkraft/src/fetch.ts
+++ b/solarkraft/src/fetch.ts
@@ -10,64 +10,90 @@
  */
 
 import { Horizon } from '@stellar/stellar-sdk'
-import JSONbigint from 'json-bigint'
 import { extractContractCall } from './fetcher/callDecoder.js'
+import { loadFetcherState, saveContractCallEntry, saveFetcherState } from './fetcher/storage.js'
+
+// how often to query for the latest synchronized height
+const HEIGHT_FETCHING_PERIOD = 100
 
 /**
  * Fetch transactions from the ledger
  * @param args the arguments parsed by yargs
  */
 export async function fetch(args: any) {
+    const server = new Horizon.Server(args.rpc)
+
     const contractId = args.id
     console.log(`Target contract: ${contractId}...`)
+    let fetcherState = loadFetcherState(args.home)
+    const cachedHeight = fetcherState.heights.get(contractId, 1)
+    let lastHeight = args.height
+    console.log(`Last cached height: ${cachedHeight}`)
+    if (args.height < 0) {
+        // how to fetch the latest height?
+        console.log('not implemented yet, starting with 0')
+        lastHeight = 0
+    } else if (args.height === 0) {
+        lastHeight = cachedHeight
+    } else {
+        lastHeight = args.height
+    }
+
     console.log(`Fetching fresh transactions from: ${args.rpc}...`)
-    /*
-    // read the latest height cached from the latest invocation of fetch
-    const cachedHeight = 0
-    // fetch the actual height from the RPC endpoint
-    const currentHeight = 12345
-    let startHeight =
-        args.height < 0 ? currentHeight + args.height : args.height
-    startHeight = Math.max(startHeight, cachedHeight)
-    console.log(`| ledger | cached | start |`)
-    console.log(`| ${currentHeight}  | ${cachedHeight}   | ${startHeight} |\n`)
-    */
-    const startHeight = args.height
-
-    const DURATION = 30
-    const server = new Horizon.Server(args.rpc)
-    console.log(`Fetching the ledger for ${startHeight}`)
-    const response = await server.ledgers().ledger(startHeight).call()
-    //console.log(response)
+    
+    console.log(`Fetching the ledger for ${lastHeight}`)
+    const response = await server.ledgers().ledger(lastHeight).call()
     const startCursor = (response as any).paging_token
+    // timeout id, if a timeout is set below
+    let timeout
 
-    // See:
-    // https://github.com/stellar/js-stellar-sdk/blob/master/test/integration/streaming_test.js
-    const finish = (err) => {
+    const done = (err) => {
+        // Closing handler:
+        // https://github.com/stellar/js-stellar-sdk/blob/master/test/integration/streaming_test.js
         clearTimeout(timeout)
         closeHandler()
         console.error(err)
     }
 
-    // TODO: work in progress
+    // the number of received events
+    let nEvents = 0
+
+    // initiate the streaming loop
     const closeHandler = server
         .operations()
         .cursor(startCursor)
         .stream({
             onmessage: async (msg: any) => {
-                if (msg.transaction_successful === true) {
-                    ;(
-                        await extractContractCall(
-                            msg,
-                            (id) => contractId === id
-                        )
-                    ).map((e) => {
-                        console.log(`call => ${JSONbigint.stringify(e)}`)
-                    })
+                if (msg.transaction_successful) {
+                    const callEntryMaybe =
+                        await extractContractCall(msg, (id) => contractId === id)
+                    if (callEntryMaybe.isJust()) {
+                        const entry = callEntryMaybe.value
+                        console.log(`+ save: ${entry.height}`)
+                        saveContractCallEntry(args.home, entry)
+                    }
+                } // else: shall we also store reverted transactions?
+
+                nEvents++
+                if (nEvents % HEIGHT_FETCHING_PERIOD === 0) {
+                    // Fetch the height of the current message.
+                    // Note that messages may come slightly out of order, so the heights are not precise.
+                    const tx = await msg.transaction()
+                    lastHeight = Math.max(lastHeight, tx.ledger_attr)
+                    console.log(`= at: ${lastHeight}`)
+                    // load and save the state, other fetchers may work concurrently
+                    fetcherState = loadFetcherState(args.home)
+                    fetcherState = { ...fetcherState, heights: fetcherState.heights.set(contractId, lastHeight) }
+                    saveFetcherState(args.home, fetcherState)
                 }
             },
-            onerror: finish,
+            onerror: done,
         })
 
-    const timeout = setTimeout(finish, DURATION * 1000)
+    if (args.timeout > 0) {
+        console.log(`Fetching transactions for ${args.timeout} seconds.`)
+        timeout = setTimeout(done, args.timeout * 1000)
+    } else {
+        console.log('Fetching transactions indefinitely. Close with Ctrl-C.')
+    }
 }

--- a/solarkraft/src/fetcher/storage.ts
+++ b/solarkraft/src/fetcher/storage.ts
@@ -156,6 +156,7 @@ export function loadFetcherState(home: string): FetcherState {
  */
 export function saveFetcherState(home: string, state: FetcherState): string {
     const filename = getFetcherStateFilename(home)
+    mkdirSync(home, { recursive: true })
     const simplified = {
         heights: state.heights.toArray(),
     }
@@ -177,14 +178,13 @@ function getEntryFilename(root: string, entry: ContractCallEntry) {
 }
 
 /**
- * Get the filename for a contract call entry. Create the parent directory, if required.
+ * Get the filename for the fetcher state.
  *
  * @param root storage root
  * @param entry call entry
  * @returns the filename
  */
 function getFetcherStateFilename(root: string) {
-    mkdirSync(root, { recursive: true })
     return join(root, 'fetcher-state.json')
 }
 

--- a/solarkraft/src/fetcher/storage.ts
+++ b/solarkraft/src/fetcher/storage.ts
@@ -75,6 +75,7 @@ export interface FetcherState {
     /**
      * For every contract id, store the ledger height,
      * up to which the transactions were fetched.
+     * Similar to Stellar SDK, we are using number instead of bigint.
      */
     heights: OrderedMap<string, number>
 }
@@ -85,7 +86,7 @@ export interface FetcherState {
  * @returns path to the transactions storage
  */
 export function storagePath(solarkraftHome: string): string {
-    return join(solarkraftHome, ".stor")
+    return join(solarkraftHome, '.stor')
 }
 
 /**
@@ -137,7 +138,7 @@ export function loadFetcherState(home: string): FetcherState {
     if (!existsSync(filename)) {
         // just return an empty map
         return {
-            heights: OrderedMap<string, number>()
+            heights: OrderedMap<string, number>(),
         }
     } else {
         const contents = readFileSync(filename)
@@ -161,7 +162,7 @@ export function saveFetcherState(home: string, state: FetcherState): string {
     const contents = JSONbig.stringify(simplified)
     writeFileSync(filename, contents)
     return filename
-} 
+}
 
 /**
  * Get the filename for a contract call entry. Create the parent directory, if required.

--- a/solarkraft/src/fetcher/storage.ts
+++ b/solarkraft/src/fetcher/storage.ts
@@ -137,13 +137,13 @@ export function loadFetcherState(home: string): FetcherState {
     if (!existsSync(filename)) {
         // just return an empty map
         return {
-            heights: OrderedMap<string, any>()
+            heights: OrderedMap<string, number>()
         }
     } else {
         const contents = readFileSync(filename)
         const loaded = JSONbig.parse(contents)
         return {
-            heights: OrderedMap<string, any>(loaded.heights),
+            heights: OrderedMap<string, number>(loaded.heights),
         }
     }
 }

--- a/solarkraft/src/fetcher/storage.ts
+++ b/solarkraft/src/fetcher/storage.ts
@@ -12,7 +12,7 @@
 import JSONbigint from 'json-bigint'
 import { OrderedMap } from 'immutable'
 import { join } from 'node:path/posix'
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 
 const JSONbig = JSONbigint({ useNativeBigInt: true })
 
@@ -69,12 +69,32 @@ export interface ContractCallEntry {
 }
 
 /**
+ * Serializable fetcher state.
+ */
+export interface FetcherState {
+    /**
+     * For every contract id, store the ledger height,
+     * up to which the transactions were fetched.
+     */
+    heights: OrderedMap<string, number>
+}
+
+/**
+ * Given the solarkraft home, construct the path to store the transactions.
+ * @param solarkraftHome path to solarkraft home (or project directory)
+ * @returns path to the transactions storage
+ */
+export function storagePath(solarkraftHome: string): string {
+    return join(solarkraftHome, ".stor")
+}
+
+/**
  * Store a contract call entry in the file storage.
- * @param root the storage root directory
+ * @param home the storage root directory
  * @param entry a call entry
  */
-export function saveContractCallEntry(root: string, entry: ContractCallEntry) {
-    const filename = getEntryFilename(root, entry)
+export function saveContractCallEntry(home: string, entry: ContractCallEntry) {
+    const filename = getEntryFilename(storagePath(home), entry)
     // convert OrderedMaps to arrays
     const simplified = {
         ...entry,
@@ -108,6 +128,42 @@ export function loadContractCallEntry(filename: string): ContractCallEntry {
 }
 
 /**
+ * Load fetcher state from the storage.
+ * @param root the storage root directory
+ * @returns the loaded state
+ */
+export function loadFetcherState(home: string): FetcherState {
+    const filename = getFetcherStateFilename(home)
+    if (!existsSync(filename)) {
+        // just return an empty map
+        return {
+            heights: OrderedMap<string, any>()
+        }
+    } else {
+        const contents = readFileSync(filename)
+        const loaded = JSONbig.parse(contents)
+        return {
+            heights: OrderedMap<string, any>(loaded.heights),
+        }
+    }
+}
+
+/**
+ * Store the fetcher config.
+ * @param home the storage root directory
+ * @param state fetcher state
+ */
+export function saveFetcherState(home: string, state: FetcherState): string {
+    const filename = getFetcherStateFilename(home)
+    const simplified = {
+        heights: state.heights.toArray(),
+    }
+    const contents = JSONbig.stringify(simplified)
+    writeFileSync(filename, contents)
+    return filename
+} 
+
+/**
  * Get the filename for a contract call entry. Create the parent directory, if required.
  *
  * @param root storage root
@@ -117,6 +173,18 @@ export function loadContractCallEntry(filename: string): ContractCallEntry {
 function getEntryFilename(root: string, entry: ContractCallEntry) {
     const dir = getOrCreateDirectory(root, entry)
     return join(dir, `entry-${entry.txHash}.json`)
+}
+
+/**
+ * Get the filename for a contract call entry. Create the parent directory, if required.
+ *
+ * @param root storage root
+ * @param entry call entry
+ * @returns the filename
+ */
+function getFetcherStateFilename(root: string) {
+    mkdirSync(root, { recursive: true })
+    return join(root, 'fetcher-state.json')
 }
 
 /**

--- a/solarkraft/src/main.ts
+++ b/solarkraft/src/main.ts
@@ -10,14 +10,22 @@ import { version } from './version.js'
 import { fetch } from './fetch.js'
 import { verify } from './verify.js'
 import { list } from './list.js'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
 
 // The default options present in every command
 const defaultOpts = (yargs: any) =>
     yargs.option('color', {
-        desc: 'color output',
-        type: 'boolean',
-        default: true,
-    })
+            desc: 'color output',
+            type: 'boolean',
+            default: true,
+        })
+        .option('home', {
+            desc: 'Solarkraft home directory (or project directory)',
+            type: 'string',
+            default: join(homedir(), '.solarkraft'),
+        })
+
 
 // fetch: transaction extractor
 const fetchCmd = {
@@ -31,14 +39,19 @@ const fetchCmd = {
                 require: true,
             })
             .option('rpc', {
-                desc: 'URL of the Stellar RPC',
+                desc: 'URL of a Horizon endpoint',
                 type: 'string',
-                default: 'http://localhost:8000',
+                default: 'https://horizon-testnet.stellar.org',
             })
             .option('height', {
                 desc: 'The height to start with (a negative value -n goes from the latest block - n)',
                 type: 'number',
                 default: -10,
+            })
+            .option('timeout', {
+                desc: 'Fetcher timeout in seconds (when 0, fetch indefinitely long)',
+                type: 'number',
+                default: 0,
             }),
     handler: fetch,
 }

--- a/solarkraft/src/main.ts
+++ b/solarkraft/src/main.ts
@@ -15,7 +15,8 @@ import { homedir } from 'node:os'
 
 // The default options present in every command
 const defaultOpts = (yargs: any) =>
-    yargs.option('color', {
+    yargs
+        .option('color', {
             desc: 'color output',
             type: 'boolean',
             default: true,
@@ -25,7 +26,6 @@ const defaultOpts = (yargs: any) =>
             type: 'string',
             default: join(homedir(), '.solarkraft'),
         })
-
 
 // fetch: transaction extractor
 const fetchCmd = {

--- a/solarkraft/test/unit/storage.test.ts
+++ b/solarkraft/test/unit/storage.test.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path'
 import {
     loadContractCallEntry,
     saveContractCallEntry,
+    storagePath,
 } from '../../src/fetcher/storage.js'
 import { OrderedMap } from 'immutable'
 
@@ -48,7 +49,7 @@ describe('storage tests', () => {
 
         assert.equal(
             filename,
-            join(root, CONTRACT_ID, '1000', `entry-${TX_HASH}.json`)
+            join(storagePath(root), CONTRACT_ID, '1000', `entry-${TX_HASH}.json`)
         )
     })
 

--- a/solarkraft/test/unit/storage.test.ts
+++ b/solarkraft/test/unit/storage.test.ts
@@ -49,7 +49,12 @@ describe('storage tests', () => {
 
         assert.equal(
             filename,
-            join(storagePath(root), CONTRACT_ID, '1000', `entry-${TX_HASH}.json`)
+            join(
+                storagePath(root),
+                CONTRACT_ID,
+                '1000',
+                `entry-${TX_HASH}.json`
+            )
         )
     })
 


### PR DESCRIPTION
This PR adds relatively small changes on top of #55. The fetcher is fetching the transactions and saving them in the storage. For example:

```sh
$ solarkraft fetch --rpc https://horizon-testnet.stellar.org --id CC22QGTOUMERDNIYN7TPNX3V6EMPHQXVSRR3XY56EADF7YTFISD2ROND --height 1638368
Target contract: CC22QGTOUMERDNIYN7TPNX3V6EMPHQXVSRR3XY56EADF7YTFISD2ROND...
Last cached height: 1638598
Fetching fresh transactions from: https://horizon-testnet.stellar.org...
Fetching the ledger for 1638368
Fetching transactions indefinitely. Close with Ctrl-C.
+ save: 1638369
+ save: 1638371
+ save: 1638370
+ save: 1638372
+ save: 1638373
+ save: 1638374
+ save: 1638375
+ save: 1638376
+ save: 1638378
+ save: 1638377
+ save: 1638379
+ save: 1638380
+ save: 1638381
+ save: 1638382
+ save: 1638383
= at: 1638412
= at: 1638456
```

I will add an integration test for the above later today.