### PR TITLE
Support all Soroban primitive types

### DIFF
--- a/solarkraft/test/unit/instrument.test.ts
+++ b/solarkraft/test/unit/instrument.test.ts
@@ -5,7 +5,11 @@ import { describe, it } from 'mocha'
 
 import { OrderedMap } from 'immutable'
 
-import { instrumentMonitor } from '../../src/instrument.js'
+import {
+    instrumentMonitor,
+    tlaJsonTypeOfValue,
+    tlaJsonValueOfNative,
+} from '../../src/instrument.js'
 
 import { instrumentedMonitor as expected } from './verify.instrumentedMonitor.js'
 
@@ -63,5 +67,34 @@ describe('Apalache JSON instrumentor', () => {
         }
         const instrumented = instrumentMonitor(monitor, contractCall)
         assert.deepEqual(expected, instrumented)
+    })
+
+    it('decodes Soroban values to Apalache JSON IR values', () => {
+        assert.equal(true, tlaJsonValueOfNative(true))
+        assert.equal(false, tlaJsonValueOfNative(false))
+        assert.equal(-42000, tlaJsonValueOfNative(-42000))
+        assert.equal(0, tlaJsonValueOfNative(0))
+        assert.equal(1, tlaJsonValueOfNative(1))
+        assert.equal(42000, tlaJsonValueOfNative(42000))
+        assert.equal('', tlaJsonValueOfNative(''))
+        assert.equal('asdf', tlaJsonValueOfNative('asdf'))
+        assert.equal('00', tlaJsonValueOfNative({ type: 'Buffer', data: [0] }))
+        assert.equal(
+            'beef',
+            tlaJsonValueOfNative({ type: 'Buffer', data: [190, 239] })
+        )
+    })
+
+    it('finds appropriate types for values', () => {
+        assert.equal('TlaBool', tlaJsonTypeOfValue(true))
+        assert.equal('TlaBool', tlaJsonTypeOfValue(false))
+        assert.equal('TlaInt', tlaJsonTypeOfValue(-42000))
+        assert.equal('TlaInt', tlaJsonTypeOfValue(0))
+        assert.equal('TlaInt', tlaJsonTypeOfValue(1))
+        assert.equal('TlaInt', tlaJsonTypeOfValue(42000))
+        assert.equal('TlaStr', tlaJsonTypeOfValue(''))
+        assert.equal('TlaStr', tlaJsonTypeOfValue('asdf'))
+        assert.equal('TlaStr', tlaJsonTypeOfValue('00'))
+        assert.equal('TlaStr', tlaJsonTypeOfValue('beef'))
     })
 })


### PR DESCRIPTION
Add support for all Soroban [primitive types](https://developers.stellar.org/docs/learn/smart-contract-internals/types/built-in-types#primitive-types), plus `Bytes`, `BytesN` and `Address` in the checker.

In addition to the unit tests here, I have an on-chain E2E test based on the setter contract that I'll add in a follow-up PR once all its fields/types are supported.

Next step is to address `Map` and `Vec` (#46), then enums and structs (#73).