### PR TITLE
Adds programmatic alert contract invocation

### DIFF
--- a/ContractExamples/scripts/alert-deploy.sh
+++ b/ContractExamples/scripts/alert-deploy.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Deploy the alert contract
+#
+# Jure Kukovec, 2024
+#
+# @license
+# [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+
+
+set -e
+
+dir=$(cd `dirname $0`; pwd -P)
+
+cd ${dir}/..
+
+NET=testnet
+(soroban network ls | grep -q $NET) || (echo "add testnet via soroban network"; exit 1)
+
+ACCOUNT=alice
+soroban keys address $ACCOUNT || (echo "add the account $ALICE via soroban keys generate"; exit 1)
+
+
+set -x
+
+soroban contract build
+soroban contract deploy --wasm target/wasm32-unknown-unknown/release/alert.wasm \
+      --source $ACCOUNT --network $NET

--- a/solarkraft/package.json
+++ b/solarkraft/package.json
@@ -30,6 +30,7 @@
     "dist/**/*"
   ],
   "scripts": {
+    "alert": "mocha --timeout 0 --loader=ts-node/esm test/alert/**/*.test.ts",
     "compile": "genversion -e src/version.ts && tsc",
     "e2e": "mocha --loader=ts-node/esm test/e2e/**/*.test.ts",
     "format": "prettier --config .prettierrc 'src/**/*.ts' 'test/**/*.ts' --write",

--- a/solarkraft/src/MonitorAnalysis.ts
+++ b/solarkraft/src/MonitorAnalysis.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
+export enum MonitorAnalysisStatus {
+    NoViolation = 0,
+    Violation = 1,
+    Unknown = 2,
+}

--- a/solarkraft/src/invokeAlert.ts
+++ b/solarkraft/src/invokeAlert.ts
@@ -1,0 +1,116 @@
+import {
+    Contract,
+    SorobanRpc,
+    TransactionBuilder,
+    Networks,
+    BASE_FEE,
+    xdr,
+    Keypair,
+    scValToNative,
+} from '@stellar/stellar-sdk'
+import { MonitorAnalysisStatus } from './MonitorAnalysis.js'
+import { Api } from '@stellar/stellar-sdk/lib/soroban/api.js'
+
+/**
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
+
+const AlertMethodName = 'emit_and_store_violation'
+export const LocalRPC = 'https://localhost:8000/'
+export const TestnetRPC = 'https://soroban-testnet.stellar.org:443'
+
+/**
+ * When we have obtained a `MonitorAnalysisStatus` for a given monitor, we can submit it to the
+ * alert contract via the Soroban rpc.
+ *
+ * adapted from https://developers.stellar.org/docs/learn/smart-contract-internals/contract-interactions/stellar-transaction
+ */
+export async function invokeAlert(
+    sorobanRpcServer: string,
+    sourceKeypair: Keypair,
+    networkType: Networks,
+    alertContractId: string,
+    txHash: string,
+    monitorAnalysisStatus: MonitorAnalysisStatus
+): Promise<MonitorAnalysisStatus> {
+    const alertContract = new Contract(alertContractId)
+    const server = new SorobanRpc.Server(sorobanRpcServer)
+
+    // We have to build the method params from the JS ones
+    const txHashAsScVal = xdr.ScVal.scvString(txHash)
+    // Enums are equivalent to their u32 values
+    const monitorAnalysisStatusAsScVal = xdr.ScVal.scvU32(monitorAnalysisStatus)
+
+    const sourceAccount = await server.getAccount(sourceKeypair.publicKey())
+
+    const builtTransaction = new TransactionBuilder(sourceAccount, {
+        fee: BASE_FEE,
+        networkPassphrase: networkType,
+    })
+        .addOperation(
+            alertContract.call(
+                AlertMethodName,
+                txHashAsScVal,
+                monitorAnalysisStatusAsScVal
+            )
+        )
+        // This transaction will be valid for the next 30 seconds
+        .setTimeout(30)
+        .build()
+
+    // We use the RPC server to "prepare" the transaction. This simulating the
+    // transaction, discovering the storage footprint, and updating the
+    // transaction to include that footprint. If you know the footprint ahead of
+    // time, you could manually use `addFootprint` and skip this step.
+    const preparedTransaction =
+        await server.prepareTransaction(builtTransaction)
+
+    // Sign the transaction with the source account's keypair.
+    preparedTransaction.sign(sourceKeypair)
+
+    // Let's see the base64-encoded XDR of the transaction we just built.
+    console.log(
+        `Signed prepared transaction XDR: ${preparedTransaction
+            .toEnvelope()
+            .toXDR('base64')}`
+    )
+
+    // Submit the transaction to the Soroban-RPC server. The RPC server will
+    // then submit the transaction into the network for us. Then we will have to
+    // wait, polling `getTransaction` until the transaction completes.
+    try {
+        const sendResponse = await server.sendTransaction(preparedTransaction)
+        console.log(`Sent transaction: ${JSON.stringify(sendResponse)}`)
+
+        if (sendResponse.status === 'PENDING') {
+            let getResponse = await server.getTransaction(sendResponse.hash)
+            // Poll `getTransaction` until the status is not "NOT_FOUND"
+            while (getResponse.status === Api.GetTransactionStatus.NOT_FOUND) {
+                console.log('Waiting for transaction confirmation...')
+                // See if the transaction is complete
+                getResponse = await server.getTransaction(sendResponse.hash)
+                // Wait one second
+                await new Promise((resolve) => setTimeout(resolve, 1000))
+            }
+
+            if (getResponse.status === Api.GetTransactionStatus.SUCCESS) {
+                // Find the return value from the contract and return it
+                const returnValue = getResponse.returnValue
+                console.log(`Transaction successful`)
+
+                return scValToNative(returnValue) as MonitorAnalysisStatus
+            } else {
+                throw `Transaction failed: ${getResponse.resultXdr}`
+            }
+        } else {
+            throw sendResponse.errorResult
+        }
+    } catch (err) {
+        // Catch and report any errors we've thrown
+        console.log('Sending transaction failed')
+        console.log(JSON.stringify(err))
+
+        return MonitorAnalysisStatus.Unknown
+    }
+}

--- a/solarkraft/test/alert/invokeAlert.test.ts
+++ b/solarkraft/test/alert/invokeAlert.test.ts
@@ -1,0 +1,37 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import { invokeAlert, TestnetRPC } from '../../src/invokeAlert.js'
+import { Keypair, Networks } from '@stellar/stellar-sdk'
+import { MonitorAnalysisStatus } from '../../src/MonitorAnalysis.js'
+
+// hard-coded contract id that has to be changed,
+// when the Setter contract is redeployed via alert-deploy.sh
+const CONTRACT_ID = 'CDXBZCCRCCIHSHHXONEFX4DOD5XSM34EA7M22JIVU35ZDQ6ZBADIARLB'
+
+describe('Alert contract invocation', () => {
+    it('Submits a NoViolation', async () => {
+        // set up a new account adn initial funds, to submit txs from
+        const sourceKeypair = Keypair.random()
+        try {
+            await fetch(
+                `https://friendbot.stellar.org?addr=${encodeURIComponent(sourceKeypair.publicKey())}`
+            )
+        } catch (e) {
+            assert(false)
+        }
+
+        const txHash = 'a'.repeat(64)
+
+        const ret = await invokeAlert(
+            TestnetRPC,
+            sourceKeypair,
+            Networks.TESTNET,
+            CONTRACT_ID,
+            txHash,
+            MonitorAnalysisStatus.NoViolation
+        )
+
+        assert(ret === MonitorAnalysisStatus.NoViolation)
+    })
+})


### PR DESCRIPTION
Closes #67 

Adds a method `invokeAlert`, which submits the monitor analysis status to the alert contract.
Calling `invokeAlert` requires a known `sorobanRpcServer`, as well as an account/keypair with which to sign/submit transactions. In the test, the latter are randomly generated and funded, but we should probably hardcode them to cut down on response waiting times.