### PR TITLE
Small devcontainer improvements

### DIFF
--- a/solarkraft/.devcontainer/Dockerfile
+++ b/solarkraft/.devcontainer/Dockerfile
@@ -1,3 +1,4 @@
 # Force platform to linux/amd64; there is no Z3 release for linux/arm64:
 # https://github.com/Z3Prover/z3/issues/7201
 FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/typescript-node:20-bookworm
+ENV PATH="/opt/apalache/bin/:${PATH}"

--- a/solarkraft/.devcontainer/devcontainer.json
+++ b/solarkraft/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"alygin.vscode-tlaplus",
+				"alygin.vscode-tlaplus-nightly",
 				"vscodevim.vim"
 			],
 			"settings": {


### PR DESCRIPTION
2 small improvements to the Solarkraft devcontainer:
1. include the Apalache in the `PATH` env
2. install the TLA+ VSCode extension (nightly, because the regular release is heavily outdated and I couldn't get it to install inside the devcontainer)