### PR TITLE
Fixes hardcoded Apalache path

### DIFF
--- a/solarkraft/src/environment.d.ts
+++ b/solarkraft/src/environment.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
+ */
+declare global {
+    namespace NodeJS {
+        interface ProcessEnv {
+            APALACHE_HOME: string
+        }
+    }
+}
+
+export {}

--- a/solarkraft/src/verify.ts
+++ b/solarkraft/src/verify.ts
@@ -18,8 +18,11 @@ import { instrumentMonitor } from './instrument.js'
 type Result<T> = Either<string, T>
 type ApalacheResult = Result<void>
 
-// TODO(#34): fix hardcoded path to Apalache
-const APALACHE_DIST = '/opt/apalache'
+// Looks for the Apalache path under $APALACHE_HOME. If undefined, uses /opt/apalache
+const APALACHE_DIST =
+    typeof process.env.APALACHE_HOME === 'undefined'
+        ? '/opt/apalache'
+        : process.env.APALACHE_HOME
 const APALACHE_BIN = path.join(APALACHE_DIST, 'bin', 'apalache-mc')
 
 /**


### PR DESCRIPTION
closes #34

Instead of looking at a fixed directory, attempts to read the `$APALACHE_HOME` environment variable.