### PR TITLE
[DRAFT] Instrument function return value

### DIFF
--- a/solarkraft/src/instrument.ts
+++ b/solarkraft/src/instrument.ts
@@ -130,8 +130,26 @@ export function instrumentMonitor(
 
     // Declaration of "Next" (according to `contractCall.fields` and `contractCall.method` / `.methodArgs`)
     const envRecord = tlaJsonRecord([
-        { name: 'height', kind: 'TlaInt', value: contractCall.height },
-        { name: 'timestamp', kind: 'TlaInt', value: contractCall.timestamp },
+        // env.ledger().sequence()
+        {
+            name: 'sequence',
+            value: tlaJsonValEx('TlaInt', contractCall.height),
+        },
+        // env.ledger().timestamp()
+        {
+            name: 'timestamp',
+            value: tlaJsonValEx('TlaInt', contractCall.timestamp),
+        },
+        // env.current_contract_address()
+        {
+            name: 'current_contract_address',
+            value: tlaJsonValEx('TlaStr', contractCall.contractId),
+        },
+        // extra environment that's useful in monitor specifications
+        {
+            name: 'invoked_function_name',
+            value: tlaJsonValEx('TlaStr', contractCall.method),
+        },
     ])
 
     const currentInstrumented = tlaJsonAnd(
@@ -229,6 +247,11 @@ export function isTlaName(name: string): boolean {
  *   { "2": 3, "4": 5 }  ~~>  SetAsFun({ <<"2", 3>>, <<"4", 5>> })
  */
 export function tlaJsonOfNative(v: any, forceVec: boolean = false): any {
+    assert(
+        v !== null && v !== undefined,
+        `Expected value, got null or undefined`
+    )
+
     if (typeof v === 'object') {
         if (Array.isArray(v)) {
             // a JS array
@@ -376,14 +399,14 @@ function tlaJsonValEx(kind: string, value: any): any {
  * @param bindings Interleaved array of field names and field values.
  * @returns The record in Apalache IR JSON: https://apalache.informal.systems/docs/adr/005adr-json.html
  */
-function tlaJsonRecord(bindings: any): any {
+function tlaJsonRecord(bindings: { name; value }[]): any {
     return {
         type: 'Untyped',
         kind: 'OperEx',
         oper: 'RECORD',
-        args: bindings.flatMap((binding) => [
-            tlaJsonValEx('TlaStr', binding.name),
-            tlaJsonValEx(binding.kind, binding.value),
+        args: bindings.flatMap(({ name, value }) => [
+            tlaJsonValEx('TlaStr', name),
+            value,
         ]),
     }
 }

--- a/solarkraft/test/unit/instrument.test.ts
+++ b/solarkraft/test/unit/instrument.test.ts
@@ -10,6 +10,7 @@ import {
     tlaJsonTypeOfPrimitive,
     tlaJsonOfNative,
     isTlaName,
+    tlaJsonOptionOfNative,
 } from '../../src/instrument.js'
 
 import { instrumentedMonitor as expected } from './verify.instrumentedMonitor.js'
@@ -256,5 +257,42 @@ describe('Apalache JSON instrumentor', () => {
 
         assert.isFalse(isTlaName('3'))
         assert.isFalse(isTlaName('_'))
+    })
+
+    it('converts option types', () => {
+        const tlaJsonNone = {
+            type: 'Untyped',
+            kind: 'OperEx',
+            oper: 'OPER_APP',
+            args: [
+                {
+                    type: 'Untyped',
+                    kind: 'NameEx',
+                    name: 'None',
+                },
+            ],
+        }
+        assert.deepEqual(tlaJsonOptionOfNative(null), tlaJsonNone)
+        assert.deepEqual(tlaJsonOptionOfNative(undefined), tlaJsonNone)
+        assert.deepEqual(tlaJsonOptionOfNative(42), {
+            type: 'Untyped',
+            kind: 'OperEx',
+            oper: 'OPER_APP',
+            args: [
+                {
+                    type: 'Untyped',
+                    kind: 'NameEx',
+                    name: 'Some',
+                },
+                {
+                    type: 'Untyped',
+                    kind: 'ValEx',
+                    value: {
+                        kind: 'TlaInt',
+                        value: 42,
+                    },
+                },
+            ],
+        })
     })
 })

--- a/solarkraft/test/unit/verify.instrumentedMonitor.ts
+++ b/solarkraft/test/unit/verify.instrumentedMonitor.ts
@@ -84,7 +84,7 @@ const instrumentedMonitor = {
                                                 type: 'Untyped',
                                                 value: {
                                                     kind: 'TlaStr',
-                                                    value: 'height',
+                                                    value: 'sequence',
                                                 },
                                             },
                                             {
@@ -109,6 +109,38 @@ const instrumentedMonitor = {
                                                 value: {
                                                     kind: 'TlaInt',
                                                     value: 1716393856,
+                                                },
+                                            },
+                                            {
+                                                kind: 'ValEx',
+                                                type: 'Untyped',
+                                                value: {
+                                                    kind: 'TlaStr',
+                                                    value: 'current_contract_address',
+                                                },
+                                            },
+                                            {
+                                                kind: 'ValEx',
+                                                type: 'Untyped',
+                                                value: {
+                                                    kind: 'TlaStr',
+                                                    value: '0xqwer',
+                                                },
+                                            },
+                                            {
+                                                kind: 'ValEx',
+                                                type: 'Untyped',
+                                                value: {
+                                                    kind: 'TlaStr',
+                                                    value: 'invoked_function_name',
+                                                },
+                                            },
+                                            {
+                                                kind: 'ValEx',
+                                                type: 'Untyped',
+                                                value: {
+                                                    kind: 'TlaStr',
+                                                    value: 'Claim',
                                                 },
                                             },
                                         ],

--- a/solarkraft/test/unit/verify.instrumentedMonitor2.ts
+++ b/solarkraft/test/unit/verify.instrumentedMonitor2.ts
@@ -116,7 +116,7 @@ const instrumentedMonitor = {
                                                 type: 'Untyped',
                                                 value: {
                                                     kind: 'TlaStr',
-                                                    value: 'height',
+                                                    value: 'sequence',
                                                 },
                                             },
                                             {
@@ -141,6 +141,38 @@ const instrumentedMonitor = {
                                                 value: {
                                                     kind: 'TlaInt',
                                                     value: 1716393856,
+                                                },
+                                            },
+                                            {
+                                                kind: 'ValEx',
+                                                type: 'Untyped',
+                                                value: {
+                                                    kind: 'TlaStr',
+                                                    value: 'current_contract_address',
+                                                },
+                                            },
+                                            {
+                                                kind: 'ValEx',
+                                                type: 'Untyped',
+                                                value: {
+                                                    kind: 'TlaStr',
+                                                    value: '0xqwer',
+                                                },
+                                            },
+                                            {
+                                                kind: 'ValEx',
+                                                type: 'Untyped',
+                                                value: {
+                                                    kind: 'TlaStr',
+                                                    value: 'invoked_function_name',
+                                                },
+                                            },
+                                            {
+                                                kind: 'ValEx',
+                                                type: 'Untyped',
+                                                value: {
+                                                    kind: 'TlaStr',
+                                                    value: 'Claim',
                                                 },
                                             },
                                         ],


### PR DESCRIPTION
Draft PR for instrumenting the invoked function's return value into the env.

Since the return value may be `()`, the plan is to use the [Apalache option type](https://apalache.informal.systems/docs/lang/option-types.html).
However, the required operators are not loaded by default, and would need to be injected into the JSON IR.

Also, we would have likely have to annotate the env record field with an appropriate type.

Closes #88