### PR TITLE
Correctness fix in default status

### DIFF
--- a/solarkraft/src/verify.ts
+++ b/solarkraft/src/verify.ts
@@ -238,7 +238,7 @@ export function verify(args: any) {
                 ? VerificationStatus.Unknown // Unknown on one monitor + NoViolation on another gives us Unknown overall
                 : res // NoViolation on monitors so far gives us whatever the current result is
         },
-        VerificationStatus.Unknown // Array is empty
+        VerificationStatus.NoViolation // Array is empty
     )
 
     conditionalAlert(verificationStatus, args.txHash, args.alert)


### PR DESCRIPTION
Found this while doing the demo, since `VerificationStatus::Unknown` absorbs `NoViolation`, the initial fold-value must be a `NoViolation`, since otherwise `Unknown` (initial) + `NoViolation` (actual result) give an `Unknown`, instead of a `NoViolation`