### PR TITLE
Move non-commands to subdir

### DIFF
--- a/solarkraft/src/verifier/instrument.ts
+++ b/solarkraft/src/verifier/instrument.ts
@@ -18,7 +18,7 @@
  */
 
 import { assert } from 'console'
-import { ContractCallEntry } from './fetcher/storage.js'
+import { ContractCallEntry } from '../fetcher/storage.js'
 
 /**
  * Expected monitor shape:

--- a/solarkraft/src/verifier/invokeAlert.ts
+++ b/solarkraft/src/verifier/invokeAlert.ts
@@ -9,7 +9,7 @@ import {
     scValToNative,
 } from '@stellar/stellar-sdk'
 import { Api } from '@stellar/stellar-sdk/rpc'
-import { VerificationStatus } from './fetcher/storage.js'
+import { VerificationStatus } from '../fetcher/storage.js'
 
 /**
  * @license

--- a/solarkraft/src/verify.ts
+++ b/solarkraft/src/verify.ts
@@ -26,8 +26,8 @@ import {
     storagePath,
     VerificationStatus,
 } from './fetcher/storage.js'
-import { instrumentMonitor } from './instrument.js'
-import { invokeAlert } from './invokeAlert.js'
+import { instrumentMonitor } from './verifier/instrument.js'
+import { invokeAlert } from './verifier/invokeAlert.js'
 
 type Result<T> = Either<string, T>
 type ApalacheResult = Result<void>

--- a/solarkraft/test/e2e/invokeAlert.test.ts
+++ b/solarkraft/test/e2e/invokeAlert.test.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai'
 import { describe, it } from 'mocha'
 import { spawn } from 'nexpect'
 
-import { invokeAlert } from '../../src/invokeAlert.js'
+import { invokeAlert } from '../../src/verifier/invokeAlert.js'
 import { Keypair, Networks } from '@stellar/stellar-sdk'
 import { VerificationStatus } from '../../src/fetcher/storage.js'
 

--- a/solarkraft/test/unit/instrument.test.ts
+++ b/solarkraft/test/unit/instrument.test.ts
@@ -10,7 +10,7 @@ import {
     tlaJsonTypeOfPrimitive,
     tlaJsonOfNative,
     isTlaName,
-} from '../../src/instrument.js'
+} from '../../src/verifier/instrument.js'
 
 import { instrumentedMonitor as expected } from './verify.instrumentedMonitor.js'
 import { instrumentedMonitor as expected2 } from './verify.instrumentedMonitor2.js'


### PR DESCRIPTION
Small refactoring that clears up the `./src/` root, to only contain entry points to the main commands `fetch`, `list`, and `verify`.

All other source files are moved to subdirectories.