### PR TITLE
Upgrade soroban-examples / soroban-sdk to v21.6.0

### DIFF
--- a/ContractExamples/Cargo.toml
+++ b/ContractExamples/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "20.3.2"
+soroban-sdk = "21.6.0"
 
 [profile.release]
 opt-level = "z"

--- a/ContractExamples/contracts/alert/Cargo.toml
+++ b/ContractExamples/contracts/alert/Cargo.toml
@@ -12,4 +12,4 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "20.3.2", features = ["testutils"] }
+soroban-sdk = { version = "21.6.0", features = ["testutils"] }

--- a/ContractExamples/contracts/megacontract/Cargo.toml
+++ b/ContractExamples/contracts/megacontract/Cargo.toml
@@ -12,4 +12,4 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "20.3.2", features = ["testutils"] }
+soroban-sdk = { version = "21.6.0", features = ["testutils"] }

--- a/ContractExamples/contracts/setter/Cargo.toml
+++ b/ContractExamples/contracts/setter/Cargo.toml
@@ -12,4 +12,4 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "20.3.2", features = ["testutils"] }
+soroban-sdk = { version = "21.6.0", features = ["testutils"] }


### PR DESCRIPTION
- Update git submodule `soroban-examples` to latest tag v21.6.0: https://github.com/stellar/soroban-examples/tree/v21.6.0
- Upgrade `soroban-sdk` dependency of local contracts to v21.6.0