### PR TITLE
Extract temporary and permanent storage changes

### DIFF
--- a/ContractExamples/contracts/setter/src/lib.rs
+++ b/ContractExamples/contracts/setter/src/lib.rs
@@ -7,8 +7,10 @@
  * @license
  * [Apache-2.0](https://github.com/freespek/solarkraft/blob/main/LICENSE)
  */
-
-use soroban_sdk::{bytes, bytesn, contract, contractimpl, contracttype, log, symbol_short, vec, Address, Bytes, BytesN, Env, Map, String, Symbol, Vec};
+use soroban_sdk::{
+    bytes, bytesn, contract, contractimpl, contracttype, log, symbol_short, vec, Address, Bytes,
+    BytesN, Env, Map, String, Symbol, Vec,
+};
 
 // scalar types
 const MY_BOOL: Symbol = symbol_short!("MY_BOOL");
@@ -46,7 +48,7 @@ pub struct MyStruct {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MyEnum {
     A(u32),
-    B(i128)
+    B(i128),
 }
 
 #[contract]
@@ -92,12 +94,16 @@ impl SetterContract {
     pub fn set_bool(env: Env, v: bool) -> bool {
         let old: bool = env.storage().instance().get(&MY_BOOL).unwrap_or(false);
         env.storage().instance().set(&MY_BOOL, &v);
+        env.storage().temporary().set(&MY_BOOL, &v);
+        env.storage().persistent().set(&MY_BOOL, &v);
         log!(&env, "myBool: {}", v);
         // bump the lifetime
         // https://developers.stellar.org/docs/learn/smart-contract-internals/state-archival
         //
         // The TTL is extended to `max_ttl` when field TTL goes below `max_ttl` - 100
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
         // return the old value to the caller
         old
     }
@@ -109,9 +115,13 @@ impl SetterContract {
     pub fn set_u32(env: Env, v: u32) -> u32 {
         let old: u32 = env.storage().instance().get(&MY_U32).unwrap_or(0);
         env.storage().instance().set(&MY_U32, &v);
+        env.storage().temporary().set(&MY_U32, &v);
+        env.storage().persistent().set(&MY_U32, &v);
         log!(&env, "myU32: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
         // return the old value to the caller
         old
     }
@@ -123,9 +133,13 @@ impl SetterContract {
     pub fn set_i32(env: Env, v: i32) -> i32 {
         let old: i32 = env.storage().instance().get(&MY_I32).unwrap_or(0);
         env.storage().instance().set(&MY_I32, &v);
+        env.storage().temporary().set(&MY_I32, &v);
+        env.storage().persistent().set(&MY_I32, &v);
         log!(&env, "myI32: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
         // return the old value to the caller
         old
     }
@@ -137,9 +151,13 @@ impl SetterContract {
     pub fn set_u64(env: Env, v: u64) -> u64 {
         let old: u64 = env.storage().instance().get(&MY_U64).unwrap_or(0);
         env.storage().instance().set(&MY_U64, &v);
+        env.storage().temporary().set(&MY_U64, &v);
+        env.storage().persistent().set(&MY_U64, &v);
         log!(&env, "myU64: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
         // return the old value to the caller
         old
     }
@@ -151,9 +169,13 @@ impl SetterContract {
     pub fn set_i64(env: Env, v: i64) -> i64 {
         let old: i64 = env.storage().instance().get(&MY_I64).unwrap_or(0);
         env.storage().instance().set(&MY_I64, &v);
+        env.storage().temporary().set(&MY_I64, &v);
+        env.storage().persistent().set(&MY_I64, &v);
         log!(&env, "myi64: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
         // return the old value to the caller
         old
     }
@@ -165,9 +187,13 @@ impl SetterContract {
     pub fn set_u128(env: Env, v: u128) -> u128 {
         let old: u128 = env.storage().instance().get(&MY_U128).unwrap_or(0);
         env.storage().instance().set(&MY_U128, &v);
+        env.storage().temporary().set(&MY_U128, &v);
+        env.storage().persistent().set(&MY_U128, &v);
         log!(&env, "myU128: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
         // return the old value to the caller
         old
     }
@@ -179,9 +205,13 @@ impl SetterContract {
     pub fn set_i128(env: Env, v: i128) -> i128 {
         let old: i128 = env.storage().instance().get(&MY_I128).unwrap_or(0);
         env.storage().instance().set(&MY_I128, &v);
+        env.storage().temporary().set(&MY_I128, &v);
+        env.storage().persistent().set(&MY_I128, &v);
         log!(&env, "myi128: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
         // return the old value to the caller
         old
     }
@@ -191,47 +221,75 @@ impl SetterContract {
     }
 
     pub fn set_sym(env: Env, v: Symbol) -> Symbol {
-        let old: Symbol = env.storage().instance().get(&MY_SYM).unwrap_or(symbol_short!("NONE"));
+        let old: Symbol = env
+            .storage()
+            .instance()
+            .get(&MY_SYM)
+            .unwrap_or(symbol_short!("NONE"));
         env.storage().instance().set(&MY_SYM, &v);
+        env.storage().temporary().set(&MY_SYM, &v);
+        env.storage().persistent().set(&MY_SYM, &v);
         log!(&env, "mySym: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
         // return the old value to the caller
         old
     }
 
     pub fn get_sym(env: Env) -> Symbol {
-        env.storage().instance().get(&MY_SYM).unwrap_or(symbol_short!("NONE"))
+        env.storage()
+            .instance()
+            .get(&MY_SYM)
+            .unwrap_or(symbol_short!("NONE"))
     }
 
     pub fn set_bytes(env: Env, v: Bytes) -> () {
         env.storage().instance().set(&MY_BYTES, &v);
+        env.storage().temporary().set(&MY_BYTES, &v);
+        env.storage().persistent().set(&MY_BYTES, &v);
         log!(&env, "myBytes: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     pub fn get_bytes(env: Env) -> Bytes {
-        env.storage().instance().get(&MY_BYTES).unwrap_or(Bytes::new(&env))
+        env.storage()
+            .instance()
+            .get(&MY_BYTES)
+            .unwrap_or(Bytes::new(&env))
     }
 
     pub fn set_bytes32(env: Env, v: BytesN<32>) -> () {
         env.storage().instance().set(&MY_BYTES32, &v);
+        env.storage().temporary().set(&MY_BYTES32, &v);
+        env.storage().persistent().set(&MY_BYTES32, &v);
         log!(&env, "myBytes32: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     pub fn get_bytes32(env: Env) -> BytesN<32> {
-        env.storage().instance().get(&MY_BYTES32)
+        env.storage()
+            .instance()
+            .get(&MY_BYTES32)
             .unwrap_or(BytesN::from_array(&env, &[0u8; 32]))
     }
 
     pub fn set_vec(env: Env, v: Vec<i32>) -> () {
         env.storage().instance().set(&MY_VEC, &v);
+        env.storage().temporary().set(&MY_VEC, &v);
+        env.storage().persistent().set(&MY_VEC, &v);
         log!(&env, "myVec: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     fn get_vec_internal(env: &Env) -> Vec<i32> {
@@ -246,18 +304,29 @@ impl SetterContract {
         let mut vs = Self::get_vec_internal(&env);
         vs.push_back(i);
         env.storage().instance().set(&MY_VEC, &vs);
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage().temporary().set(&MY_VEC, &vs);
+        env.storage().persistent().set(&MY_VEC, &vs);
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     pub fn set_map(env: Env, v: Map<u32, i32>) -> () {
         env.storage().instance().set(&MY_MAP, &v);
+        env.storage().temporary().set(&MY_MAP, &v);
+        env.storage().persistent().set(&MY_MAP, &v);
         log!(&env, "myMap: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     fn get_map_internal(env: &Env) -> Map<u32, i32> {
-        env.storage().instance().get(&MY_MAP).unwrap_or(Map::from_array(&env, [(0, 0); 0]))
+        env.storage()
+            .instance()
+            .get(&MY_MAP)
+            .unwrap_or(Map::from_array(&env, [(0, 0); 0]))
     }
 
     pub fn get_map(env: Env) -> Map<u32, i32> {
@@ -268,7 +337,11 @@ impl SetterContract {
         let mut map = Self::get_map_internal(&env);
         map.set(key, value);
         env.storage().instance().set(&MY_MAP, &map);
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage().temporary().set(&MY_MAP, &map);
+        env.storage().persistent().set(&MY_MAP, &map);
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     pub fn map_get(env: Env, key: u32) -> i32 {
@@ -277,9 +350,13 @@ impl SetterContract {
 
     pub fn set_address(env: Env, v: Address) -> () {
         env.storage().instance().set(&MY_ADDR, &v);
+        env.storage().temporary().set(&MY_ADDR, &v);
+        env.storage().persistent().set(&MY_ADDR, &v);
         log!(&env, "myAddress: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     pub fn get_address(env: Env) -> Option<Address> {
@@ -288,27 +365,38 @@ impl SetterContract {
 
     pub fn set_struct(env: Env, v: MyStruct) -> () {
         env.storage().instance().set(&MY_STRUCT, &v);
+        env.storage().temporary().set(&MY_STRUCT, &v);
+        env.storage().persistent().set(&MY_STRUCT, &v);
         log!(&env, "myStruct: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     pub fn get_struct(env: Env) -> MyStruct {
-        env.storage().instance().get(&MY_STRUCT)
-            .unwrap_or(MyStruct {
-                a: 0u32, b: 0i128
-            })
+        env.storage()
+            .instance()
+            .get(&MY_STRUCT)
+            .unwrap_or(MyStruct { a: 0u32, b: 0i128 })
     }
 
     pub fn set_enum(env: Env, v: MyEnum) -> () {
         env.storage().instance().set(&MY_ENUM, &v);
+        env.storage().temporary().set(&MY_ENUM, &v);
+        env.storage().persistent().set(&MY_ENUM, &v);
         log!(&env, "myEnum: {}", v);
         // bump the lifetime
-        env.storage().instance().extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
+        env.storage()
+            .instance()
+            .extend_ttl(env.storage().max_ttl() - 100, env.storage().max_ttl());
     }
 
     pub fn get_enum(env: Env) -> MyEnum {
-        env.storage().instance().get(&MY_ENUM).unwrap_or(MyEnum::A(0u32))
+        env.storage()
+            .instance()
+            .get(&MY_ENUM)
+            .unwrap_or(MyEnum::A(0u32))
     }
 }
 

--- a/solarkraft/src/fetcher/storage.ts
+++ b/solarkraft/src/fetcher/storage.ts
@@ -10,7 +10,7 @@
  */
 
 import JSONbigint from 'json-bigint'
-import { OrderedMap } from 'immutable'
+import Immutable, { OrderedMap } from 'immutable'
 import { join } from 'node:path/posix'
 import {
     existsSync,
@@ -115,6 +115,32 @@ export interface ContractCallEntry {
     oldFields: FieldsMap
 
     /**
+     * Ordered mapping from contract address to instance/persistent/temporary storage
+     * of the respective contract. The contract storage for a given durability is
+     * an ordered mapping from field names to their native values (JS).
+     *
+     * This mapping contains values only for the fields that have been created
+     * or updated by a transaction in the past. It may happen that
+     * `storage` contains fewer fields than `oldStorage`, when the contract
+     * deletes some fields from the storage. Also, fields may be cleared from `storage`
+     * when the storage goes over TTL.
+     */
+    oldStorage: MultiContractStorage
+
+    /**
+     * Ordered mapping from contract address to instance/persistent/temporary storage
+     * of the respective contract. The contract storage for a given durability is
+     * an ordered mapping from field names to their native values (JS).
+     *
+     * This mapping contains values only for the fields that have been created
+     * or updated by a transaction in the past. It may happen that
+     * `storage` contains fewer fields than `oldStorage`, when the contract
+     * deletes some fields from the storage. Also, fields may be cleared from `storage`
+     * when the storage goes over TTL.
+     */
+    storage: FieldsMap
+
+    /**
      * Flag which tracks whether this particular entry has already been verified, and, if it has been, the verification result.
      */
     verificationStatus?: VerificationStatus
@@ -165,7 +191,7 @@ export function saveContractCallEntry(home: string, entry: ContractCallEntry) {
     const filename = getEntryFilename(storagePath(home), entry)
     const verificationStatus: VerificationStatus =
         entry.verificationStatus ?? VerificationStatus.Unknown
-    // convert OrderedMaps to arrays
+    // convert OrderedMaps to JSON
     const simplified = {
         ...entry,
         fields: entry.fields.toArray(),
@@ -196,6 +222,8 @@ export function loadContractCallEntry(filename: string): ContractCallEntry {
         returnValue: loaded.returnValue,
         fields: OrderedMap<string, any>(loaded.fields),
         oldFields: OrderedMap<string, any>(loaded.oldFields),
+        oldStorage: Immutable.fromJS(loaded.oldStorage),
+        storage: Immutable.fromJS(loaded.storage),
         verificationStatus:
             loaded.verificationStatus ?? VerificationStatus.Unknown,
         typeHints: loaded.typeHints ?? {},

--- a/solarkraft/src/fetcher/storage.ts
+++ b/solarkraft/src/fetcher/storage.ts
@@ -27,6 +27,33 @@ const JSONbig = JSONbigint({ useNativeBigInt: true })
  * as produced by Stellar SDK.
  */
 export type FieldsMap = OrderedMap<string, any>
+export function emptyFieldsMap(): FieldsMap {
+    return OrderedMap<string, any>()
+}
+
+/**
+ * Storage of a contract.
+ */
+export type ContractStorage = {
+    instance: FieldsMap
+    persistent: FieldsMap
+    temporary: FieldsMap
+}
+export function emptyContractStorage(): ContractStorage {
+    return {
+        instance: emptyFieldsMap(),
+        persistent: emptyFieldsMap(),
+        temporary: emptyFieldsMap(),
+    }
+}
+
+/**
+ * Storage of multiple contracts, keyed by contract address.
+ */
+export type MultiContractStorage = OrderedMap<string, ContractStorage>
+export function emptyMultiContractStorage(): MultiContractStorage {
+    return OrderedMap<string, ContractStorage>()
+}
 
 /**
  * Result of `solarkraft verify`.

--- a/solarkraft/test/e2e/list.test.ts
+++ b/solarkraft/test/e2e/list.test.ts
@@ -6,7 +6,10 @@ import { spawn } from 'nexpect'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { saveContractCallEntry } from '../../src/fetcher/storage.js'
+import {
+    ContractStorage,
+    saveContractCallEntry,
+} from '../../src/fetcher/storage.js'
 import { OrderedMap } from 'immutable'
 
 const TX_HASH =
@@ -28,6 +31,8 @@ describe('list', () => {
             returnValue: 0,
             fields: OrderedMap<string, any>(),
             oldFields: OrderedMap<string, any>(),
+            oldStorage: OrderedMap<string, ContractStorage>(),
+            storage: OrderedMap<string, ContractStorage>(),
         })
 
         this.timeout(50000)

--- a/solarkraft/test/integration/callDecoder.test.ts
+++ b/solarkraft/test/integration/callDecoder.test.ts
@@ -20,7 +20,7 @@ const HORIZON_URL = 'https://horizon-testnet.stellar.org'
 
 // hard-coded contract id that has to be changed,
 // when the Setter contract is redeployed via setter-populate.sh
-const CONTRACT_ID = 'CD4MXYZJKHXHEP7YK72L6K4Y6ANFVSXSTI3VPJXV5M4QFGF5PGH5PDDJ'
+const CONTRACT_ID = 'CCIVIIO6OFFCPUU22W5HRP3UOWUGLY54TRTQXV5Z3IEOFQDMKIA2JXTZ'
 
 // 0xbeef
 const beef = Buffer.from([0xbe, 0xef])
@@ -60,7 +60,7 @@ async function extractEntry(txHash: string): Promise<ContractCallEntry> {
 describe('call decoder from Horizon', () => {
     it('call #1: Setter.set_bool(true)', async () => {
         const entry = await extractEntry(
-            'b05390b622fe133f73f2471c1b5c651e0bbafee85a7f5051012c50fa91a67e75'
+            'c7629f7deaeaf7f4450eddfa4756d252af5cab8aef4547ffb621b826eae3a2cf'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -77,15 +77,15 @@ describe('call decoder from Horizon', () => {
         assert.deepEqual(entry.storage.toJS(), {
             [CONTRACT_ID]: {
                 instance: { MY_BOOL: true },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_BOOL: true },
+                persistent: { MY_BOOL: true },
             },
         })
     })
 
     it('call #2: Setter.set_u32([42u32])', async () => {
         const entry = await extractEntry(
-            'e76a1b9e3e59528a3ddfe89954f17ff3d96eabc59332dc85b044b69443de8a2a'
+            'f29f0f4f4156acf58862f316472cc8fc153e687b85af915c8a9e11dd1c41bf26'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -109,15 +109,15 @@ describe('call decoder from Horizon', () => {
         assert.deepEqual(entry.storage.toJS(), {
             [CONTRACT_ID]: {
                 instance: { MY_BOOL: true, MY_U32: 42 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_U32: 42 },
+                persistent: { MY_U32: 42 },
             },
         })
     })
 
     it('call #3: Setter.set_i32([-42u32])', async () => {
         const entry = await extractEntry(
-            '556f1c0a1a0829213671f95827f343fb2910d07a6e7a017a56e1ff2ab3c4173d'
+            '9f5c0ce5c23f3e9508f14c6800bbdf0f5e598e7a78c38205df5dd9541483d385'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -145,15 +145,15 @@ describe('call decoder from Horizon', () => {
         assert.deepEqual(entry.storage.toJS(), {
             [CONTRACT_ID]: {
                 instance: { MY_BOOL: true, MY_U32: 42, MY_I32: -42 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_I32: -42 },
+                persistent: { MY_I32: -42 },
             },
         })
     })
 
     it('call #4: Setter.set_u64([42u64])', async () => {
         const entry = await extractEntry(
-            '8f83f2c093fe4cef11f60e74d071494c9d0e1f4b4a288b7b7fa137aa9751195d'
+            'abc11abf026f3cdfa76e1386f8ba38e84ec73f05dca9102d7aa620ff19f61478'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -188,15 +188,15 @@ describe('call decoder from Horizon', () => {
                     MY_I32: -42,
                     MY_U64: 42n,
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_U64: 42n },
+                persistent: { MY_U64: 42n },
             },
         })
     })
 
     it('call #5: Setter.set_i64([-42i64])', async () => {
         const entry = await extractEntry(
-            '91f8d67b2224aa6ad47756a72b31b5139d790d94c16c4d7bddaad6ef149650af'
+            '1cf04a4145677376837ff4d38587911bc571b6c98e35ca54b312344f68ae3025'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -239,15 +239,15 @@ describe('call decoder from Horizon', () => {
                     MY_U64: 42n,
                     MY_I64: -42n,
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_I64: -42n },
+                persistent: { MY_I64: -42n },
             },
         })
     })
 
     it('call #6: Setter.set_u128([42u128])', async () => {
         const entry = await extractEntry(
-            '8a640ba50e1b61eaa7865e10037fa8d04066c512c711081132ac4954f90ce398'
+            '63c135dcae01d93e556caaec4977c0d07d185f80cf4a9eed34d9334dafac623e'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -294,15 +294,15 @@ describe('call decoder from Horizon', () => {
                     MY_I64: -42n,
                     MY_U128: 42n,
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_U128: 42n },
+                persistent: { MY_U128: 42n },
             },
         })
     })
 
     it('call #7: Setter.set_i128([-42i128])', async () => {
         const entry = await extractEntry(
-            'f4a51fcc957c5bbb3c6f54528a605dd09988c1fc1864c40e14d12ffacc6c0458'
+            '10a33ed40724c71f0ae78453fe50f6cbaa2e6a6ccb0b1968cdd99cd1fd186968'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -353,15 +353,15 @@ describe('call decoder from Horizon', () => {
                     MY_U128: 42n,
                     MY_I128: -42n,
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_I128: -42n },
+                persistent: { MY_I128: -42n },
             },
         })
     })
 
     it('call #8: Setter.set_sym("hello")', async () => {
         const entry = await extractEntry(
-            '39bf81d229de6295e5abffa24a128fac02c584a6e2c7b17c483579fe9ed544ad'
+            '651c29141ca83c57a4c6ebd3bc757f200a2f299ecab9a2cfc4e68facd28dde2c'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -416,15 +416,15 @@ describe('call decoder from Horizon', () => {
                     MY_I128: -42n,
                     MY_SYM: 'hello',
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_SYM: 'hello' },
+                persistent: { MY_SYM: 'hello' },
             },
         })
     })
 
     it('call #9: Setter.set_bytes(0xbeef)', async () => {
         const entry = await extractEntry(
-            'fa62c7c3fdc5a8aa7c76d83c4c7eca90b63eea72d87550933ca1b5e70a86fcd9'
+            '3382c5568cc71f97adeed8511c6b69b39fcae68026e82a8219874d46e0c6c33c'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -483,15 +483,15 @@ describe('call decoder from Horizon', () => {
                     MY_SYM: 'hello',
                     MY_BYTES: beef,
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_BYTES: beef },
+                persistent: { MY_BYTES: beef },
             },
         })
     })
 
     it('call #10: Setter.set_bytes32(...)', async () => {
         const entry = await extractEntry(
-            'cf380860bbac39a5699af1d272296880020629a798af7c77b81787bba1582ffe'
+            'edb69201f2b3cc15db7bf4cac5a96098bb0cc4448c3ff23965591aa9dce42c30'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -554,15 +554,15 @@ describe('call decoder from Horizon', () => {
                     MY_BYTES: beef,
                     MY_BTES32: bytes32,
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_BTES32: bytes32 },
+                persistent: { MY_BTES32: bytes32 },
             },
         })
     })
 
     it('call #11: Setter.set_vec([[1i32, -2i32, 3i32]])', async () => {
         const entry = await extractEntry(
-            '57ca932e4670d1b98bf657f0548f1f360c8a93b18c6c62f65c3307b167c2ccbf'
+            '0b3d09453c837e0b8957760a0e62a101ebc316423634fd3d5e736f4eb94d3b8e'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -629,15 +629,15 @@ describe('call decoder from Horizon', () => {
                     MY_BTES32: bytes32,
                     MY_VEC: [1, -2, 3],
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_VEC: [1, -2, 3] },
+                persistent: { MY_VEC: [1, -2, 3] },
             },
         })
     })
 
     it('call #12: Setter.set_map([{2u32: 3i32, 4u32: 5i32}])', async () => {
         const entry = await extractEntry(
-            '1585b6e384eb52d03642c745682039e987ac93d747419b435c654b79e28dc928'
+            'f46f345896bf7ddc0b60d17b2f79e08d92dc1965befe20dd5b196b0a0daf8658'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -708,15 +708,15 @@ describe('call decoder from Horizon', () => {
                     MY_VEC: [1, -2, 3],
                     MY_MAP: { '2': 3, '4': 5 },
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_MAP: { '2': 3, '4': 5 } },
+                persistent: { MY_MAP: { '2': 3, '4': 5 } },
             },
         })
     })
 
     it('call #13: Setter.set_address([GDIY...R4W4]', async () => {
         const entry = await extractEntry(
-            '3aa904623cb321ce7c0fa4ad2d47ae90e1820bdce6f29ae339bc92c6d5f03a4b'
+            '24b513b57777b3533c0dcb15929eb35f22005d850058782325e6cd4db0349dc9'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -797,15 +797,21 @@ describe('call decoder from Horizon', () => {
                     MY_VEC: [1, -2, 3],
                     MY_MAP: { '2': 3, '4': 5 },
                 },
-                temporary: {},
-                persistent: {},
+                temporary: {
+                    MY_ADDR:
+                        'GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4',
+                },
+                persistent: {
+                    MY_ADDR:
+                        'GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4',
+                },
             },
         })
     })
 
     it('call #14: Setter.set_struct([{"a"sym: 1u32, "b"sym: -100i128}])', async () => {
         const entry = await extractEntry(
-            '8e13755bf402d2d9f9d981e0597f87b5b8af24f97e83bdfe5280757934315a48'
+            '1cc5a558453b12096b4cfdd238bd764602457b07fab5085156b0626a56220e99'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -892,15 +898,15 @@ describe('call decoder from Horizon', () => {
                     MY_VEC: [1, -2, 3],
                     MY_MAP: { '2': 3, '4': 5 },
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_STRUCT: { a: 1, b: -100n } },
+                persistent: { MY_STRUCT: { a: 1, b: -100n } },
             },
         })
     })
 
     it('call #15: Setter.set_enum([["B"sym, -200i128]])', async () => {
         const entry = await extractEntry(
-            'b695cc284078f126f1b257d5475d9520061661f0f6a1d15b0ef073e7f0602d45'
+            'd44814c5d57d547fe80ca6ce476cd39359d7cbf0941d299466be5dc7d9993def'
         )
         assert.isDefined(entry.timestamp)
         assert.isDefined(entry.height)
@@ -991,8 +997,8 @@ describe('call decoder from Horizon', () => {
                     MY_VEC: [1, -2, 3],
                     MY_MAP: { '2': 3, '4': 5 },
                 },
-                temporary: {},
-                persistent: {},
+                temporary: { MY_ENUM: ['B', -200n] },
+                persistent: { MY_ENUM: ['B', -200n] },
             },
         })
     })

--- a/solarkraft/test/integration/callDecoder.test.ts
+++ b/solarkraft/test/integration/callDecoder.test.ts
@@ -71,6 +71,16 @@ describe('call decoder from Horizon', () => {
         assert.deepEqual(entry.returnValue, false)
         assert.deepEqual(entry.oldFields.toArray(), [])
         assert.deepEqual(entry.fields.toArray(), [['MY_BOOL', true]])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: { instance: {}, temporary: {}, persistent: {} },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: { MY_BOOL: true },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #2: Setter.set_u32([42u32])', async () => {
@@ -89,6 +99,20 @@ describe('call decoder from Horizon', () => {
             ['MY_BOOL', true],
             ['MY_U32', 42],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: { MY_BOOL: true },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: { MY_BOOL: true, MY_U32: 42 },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #3: Setter.set_i32([-42u32])', async () => {
@@ -111,6 +135,20 @@ describe('call decoder from Horizon', () => {
             ['MY_I32', -42],
             ['MY_U32', 42],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: { MY_BOOL: true, MY_U32: 42 },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: { MY_BOOL: true, MY_U32: 42, MY_I32: -42 },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #4: Setter.set_u64([42u64])', async () => {
@@ -135,6 +173,25 @@ describe('call decoder from Horizon', () => {
             ['MY_U32', 42],
             ['MY_U64', 42n],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: { MY_BOOL: true, MY_U32: 42, MY_I32: -42 },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #5: Setter.set_i64([-42i64])', async () => {
@@ -161,6 +218,31 @@ describe('call decoder from Horizon', () => {
             ['MY_U32', 42],
             ['MY_U64', 42n],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #6: Setter.set_u128([42u128])', async () => {
@@ -189,6 +271,33 @@ describe('call decoder from Horizon', () => {
             ['MY_U32', 42],
             ['MY_U64', 42n],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #7: Setter.set_i128([-42i128])', async () => {
@@ -219,6 +328,35 @@ describe('call decoder from Horizon', () => {
             ['MY_U32', 42],
             ['MY_U64', 42n],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #8: Setter.set_sym("hello")', async () => {
@@ -251,6 +389,37 @@ describe('call decoder from Horizon', () => {
             ['MY_U32', 42],
             ['MY_U64', 42n],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #9: Setter.set_bytes(0xbeef)', async () => {
@@ -285,6 +454,39 @@ describe('call decoder from Horizon', () => {
             ['MY_U32', 42],
             ['MY_U64', 42n],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #10: Setter.set_bytes32(...)', async () => {
@@ -321,6 +523,41 @@ describe('call decoder from Horizon', () => {
             ['MY_U32', 42],
             ['MY_U64', 42n],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #11: Setter.set_vec([[1i32, -2i32, 3i32]])', async () => {
@@ -359,6 +596,43 @@ describe('call decoder from Horizon', () => {
             ['MY_U64', 42n],
             ['MY_VEC', [1, -2, 3]],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #12: Setter.set_map([{2u32: 3i32, 4u32: 5i32}])', async () => {
@@ -399,6 +673,45 @@ describe('call decoder from Horizon', () => {
             ['MY_U64', 42n],
             ['MY_VEC', [1, -2, 3]],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                    MY_MAP: { '2': 3, '4': 5 },
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #13: Setter.set_address([GDIY...R4W4]', async () => {
@@ -446,6 +759,48 @@ describe('call decoder from Horizon', () => {
             ['MY_U64', 42n],
             ['MY_VEC', [1, -2, 3]],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                    MY_MAP: { '2': 3, '4': 5 },
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_ADDR:
+                        'GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4',
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                    MY_MAP: { '2': 3, '4': 5 },
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #14: Setter.set_struct([{"a"sym: 1u32, "b"sym: -100i128}])', async () => {
@@ -496,6 +851,51 @@ describe('call decoder from Horizon', () => {
             ['MY_U64', 42n],
             ['MY_VEC', [1, -2, 3]],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_ADDR:
+                        'GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4',
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                    MY_MAP: { '2': 3, '4': 5 },
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_ADDR:
+                        'GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4',
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_STRUCT: { a: 1, b: -100n },
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                    MY_MAP: { '2': 3, '4': 5 },
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 
     it('call #15: Setter.set_enum([["B"sym, -200i128]])', async () => {
@@ -548,5 +948,52 @@ describe('call decoder from Horizon', () => {
             ['MY_U64', 42n],
             ['MY_VEC', [1, -2, 3]],
         ])
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_ADDR:
+                        'GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4',
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_STRUCT: { a: 1, b: -100n },
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                    MY_MAP: { '2': 3, '4': 5 },
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: {
+                    MY_ADDR:
+                        'GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4',
+                    MY_BOOL: true,
+                    MY_U32: 42,
+                    MY_I32: -42,
+                    MY_U64: 42n,
+                    MY_I64: -42n,
+                    MY_U128: 42n,
+                    MY_I128: -42n,
+                    MY_ENUM: ['B', -200n],
+                    MY_STRUCT: { a: 1, b: -100n },
+                    MY_SYM: 'hello',
+                    MY_BYTES: beef,
+                    MY_BTES32: bytes32,
+                    MY_VEC: [1, -2, 3],
+                    MY_MAP: { '2': 3, '4': 5 },
+                },
+                temporary: {},
+                persistent: {},
+            },
+        })
     })
 })

--- a/solarkraft/test/unit/instrument.test.ts
+++ b/solarkraft/test/unit/instrument.test.ts
@@ -15,6 +15,7 @@ import {
 import { instrumentedMonitor as expected } from './verify.instrumentedMonitor.js'
 import { instrumentedMonitor as expected2 } from './verify.instrumentedMonitor2.js'
 import { instrumentedMonitor as expected3 } from './verify.instrumentedMonitor3.js'
+import { ContractStorage, emptyFieldsMap } from '../../src/fetcher/storage.js'
 
 // Assert that `tlaJsonOfNative` returns a proper TLA+ `ValEx` for the primitive JS value `v`
 function assertProperValExOfPrimitive(v: any) {
@@ -134,6 +135,30 @@ describe('Apalache JSON instrumentor', () => {
             methodArgs: ['alice'],
             fields: OrderedMap<string, any>([['is_initialized', false]]),
             oldFields: OrderedMap<string, any>([['is_initialized', false]]),
+            oldStorage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['is_initialized', false],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
+            storage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['is_initialized', false],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
         }
 
         const instrumented = instrumentMonitor(monitor, contractCall)
@@ -166,6 +191,32 @@ describe('Apalache JSON instrumentor', () => {
                 ['is_initialized', false],
                 ['additional_variable', false],
             ]),
+            oldStorage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['is_initialized', false],
+                            ['additional_variable', false],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
+            storage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['is_initialized', false],
+                            ['additional_variable', false],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
         }
         const instrumented = instrumentMonitor(monitor, contractCall)
         assert.deepEqual(expected, instrumented)
@@ -192,6 +243,32 @@ describe('Apalache JSON instrumentor', () => {
             methodArgs: ['alice'],
             fields: OrderedMap<string, any>([['is_initialized', false]]),
             oldFields: OrderedMap<string, any>([['is_initialized', false]]),
+            oldStorage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['is_initialized', false],
+                            ['additional_variable', false],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
+            storage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['is_initialized', false],
+                            ['additional_variable', false],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
         }
         const instrumented = instrumentMonitor(monitor, contractCall)
         assert.deepEqual(expected2, instrumented)
@@ -217,6 +294,30 @@ describe('Apalache JSON instrumentor', () => {
             methodArgs: [['MaybeEnum']],
             fields: OrderedMap<string, any>([['is_initialized', false]]),
             oldFields: OrderedMap<string, any>([['is_initialized', false]]),
+            oldStorage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['is_initialized', false],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
+            storage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['is_initialized', false],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
             typeHints: undefined,
         }
         assert.throws(() => instrumentMonitor(monitor, contractCall))
@@ -240,6 +341,26 @@ describe('Apalache JSON instrumentor', () => {
             methodArgs: [['MaybeEnum'], ['MaybeVec']],
             fields: OrderedMap<string, any>(),
             oldFields: OrderedMap<string, any>(),
+            oldStorage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: emptyFieldsMap(),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
+            storage: OrderedMap<string, ContractStorage>([
+                [
+                    '0xqwer',
+                    {
+                        instance: emptyFieldsMap(),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
             typeHints: {
                 methods: { foo: [[{ enum: [] }, { vec: 'Str' }], 'BAR'] },
             },

--- a/solarkraft/test/unit/storage.test.ts
+++ b/solarkraft/test/unit/storage.test.ts
@@ -105,5 +105,19 @@ describe('storage tests', () => {
             ['a', 1],
             ['b', 993143214321423154315154322n],
         ])
+        assert.deepEqual(entry.storage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: { a: 3, b: 993143214321423154315154321n },
+                persistent: {},
+                temporary: {},
+            },
+        })
+        assert.deepEqual(entry.oldStorage.toJS(), {
+            [CONTRACT_ID]: {
+                instance: { a: 1, b: 993143214321423154315154322n },
+                persistent: {},
+                temporary: {},
+            },
+        })
     })
 })

--- a/solarkraft/test/unit/storage.test.ts
+++ b/solarkraft/test/unit/storage.test.ts
@@ -10,6 +10,8 @@ import { describe, it } from 'mocha'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+    ContractStorage,
+    emptyFieldsMap,
     loadContractCallEntry,
     saveContractCallEntry,
     storagePath,
@@ -39,6 +41,32 @@ describe('storage tests', () => {
             oldFields: OrderedMap<string, any>([
                 ['a', 1],
                 ['b', 993143214321423154315154322n],
+            ]),
+            oldStorage: OrderedMap<string, ContractStorage>([
+                [
+                    CONTRACT_ID,
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['a', 1],
+                            ['b', 993143214321423154315154322n],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
+            ]),
+            storage: OrderedMap<string, ContractStorage>([
+                [
+                    CONTRACT_ID,
+                    {
+                        instance: OrderedMap<string, any>([
+                            ['a', 3],
+                            ['b', 993143214321423154315154321n],
+                        ]),
+                        persistent: emptyFieldsMap(),
+                        temporary: emptyFieldsMap(),
+                    },
+                ],
             ]),
         })
 


### PR DESCRIPTION
Preparatory change towards #54.
Closes #121
Closes #126

In the fetcher, extract **all** ledger entry changes from a transaction, i.e, including
- changes to temporary and persistent storage, and
- changes to other contracts than the (root-)invoked contract.

The result is two (pre- & post-state) nested maps keyed by
1. contract address
2. 'instance' | 'persistent' | 'temporary'
3. the `ScVal` key, SDK-transformed to a native JS val and `.toString()`ed

The resulting maps are only propagated to Solarkraft on-disk storage, and not yet used for instrumentation. In particular, we still populate `fields` and `oldFields` by projecting the above maps to the instance storage of the root-invocation contract ID.

**Tests:**
Update the setter contract to store all fields in instance, persistent and temporary storage.

Note that the presence of fields is different between instance and persistent/temporary:
instance is a single `LedgerEntry`, thus all instance fields are present if a single instance field changes.
persistent/temporary have one `LedgerEntry` per field, thus they are only present in the transaction if that field is changed. 

We should follow up with case studies to determine user needs:
- #128