### PR TITLE
Separate `tokenReceived` for Stellar Asset Contract

### DIFF
--- a/solarkraft/src/verify_js.ts
+++ b/solarkraft/src/verify_js.ts
@@ -177,6 +177,8 @@ export function tokenReceived(
     const tokenStorage = env.storage(token).persistent()
 
     return (
+        // token balance is stored under a variant data key Balance(Address)
+        // that points to a struct { amount: i128, authorized: bool, clawback: bool }
         tokenStorage.get(`Balance,${to}`).amount ==
         (oldTokenStorage.get(`Balance,${to}`)?.amount ?? 0) + amount
     )
@@ -202,6 +204,8 @@ export function tokenTransferred(
     const oldTokenStorage = env.oldStorage(token).persistent()
     const tokenStorage = env.storage(token).persistent()
     return every(
+        // token balance is stored under a variant data key Balance(Address)
+        // that points to a struct { amount: i128, authorized: bool, clawback: bool }
         tokenStorage.get(`Balance,${from}`).amount ==
             oldTokenStorage.get(`Balance,${from}`)?.amount - amount,
         tokenStorage.get(`Balance,${to}`).amount ==

--- a/solarkraft/test/e2e/verify_js_example.ts
+++ b/solarkraft/test/e2e/verify_js_example.ts
@@ -43,6 +43,8 @@ function tokenTransferred(
     const oldTokenStorage = env.oldStorage(token).persistent()
     const tokenStorage = env.storage(token).persistent()
     return every(
+        // token balance is stored under a variant data key Balance(Address)
+        // that points to an i128.
         tokenStorage.get(`Balance,${from}`) ==
             oldTokenStorage.get(`Balance,${from}`) - amount,
         tokenStorage.get(`Balance,${to}`) ==

--- a/solarkraft/test/e2e/verify_js_example.ts
+++ b/solarkraft/test/e2e/verify_js_example.ts
@@ -19,12 +19,36 @@
 import {
     some,
     every,
+    Condition,
     Env,
     EnvRevert,
     SolarkraftJsMonitor,
-    tokenTransferred,
 } from '../../src/verify_js.js'
 import _ from 'lodash'
+
+// Helper function to check if a token transfer was successful.
+//
+// `timelock` is using the custom token contract from `soroban-examples`,
+// which implements the SEP-41 Token Interface, but not the storage layout
+// of a CAP-46-6 Smart Contract Standardized Asset.
+// Thus, we do not use the `tokenTransferred` function from the `verify_js`
+// module, but instead define a custom function here.
+function tokenTransferred(
+    env: Env,
+    token: string,
+    from: string,
+    to: string,
+    amount: number
+): Condition {
+    const oldTokenStorage = env.oldStorage(token).persistent()
+    const tokenStorage = env.storage(token).persistent()
+    return every(
+        tokenStorage.get(`Balance,${from}`) ==
+            oldTokenStorage.get(`Balance,${from}`) - amount,
+        tokenStorage.get(`Balance,${to}`) ==
+            oldTokenStorage.get(`Balance,${to}`, 0) + amount
+    )
+}
 
 /* generate from contract spec */
 


### PR DESCRIPTION
This is a delta to #135.

While working on #133, I realized that Stellar Asset Contracts use a different storage layout than the `soroban-examples/token` contract (in particular, they keep a struct inside the `Balance` storage, not just an `i128` amount).

In this PR, we
* move the `tokenTransferred` condition that only applies to `soroban-examples/token` out of Solarkraft, and into `verify_js_example.ts`
* provide a [CAP-46](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046.md)-compatible version of `tokenTransferred` instead
* add a [CAP-46](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046.md)-compatible condition `tokenReceived`, that checks only the receiver part of `tokenTransferred`

`tokenReceived` is necessary, because there may not be a sender balance recorded in contract storage of the SAC if the sender is transferring native tokens.