### PR TITLE
Use bigint everywhere

### DIFF
--- a/solarkraft/src/fetcher/storage.ts
+++ b/solarkraft/src/fetcher/storage.ts
@@ -24,7 +24,7 @@ import { globSync } from 'glob'
 import { left, right } from '@sweet-monads/either'
 import { Result } from '../globals.js'
 
-const JSONbig = JSONbigint({ useNativeBigInt: true })
+const JSONbig = JSONbigint({ useNativeBigInt: true, alwaysParseAsBig: true })
 
 /**
  * Ordered mapping from field names to their native values (JS),

--- a/solarkraft/src/verify_js.ts
+++ b/solarkraft/src/verify_js.ts
@@ -171,14 +171,14 @@ export function tokenReceived(
     env: Env,
     token: string,
     to: string,
-    amount: number
+    amount: bigint
 ): Condition {
     const oldTokenStorage = env.oldStorage(token).persistent()
     const tokenStorage = env.storage(token).persistent()
 
     return (
         tokenStorage.get(`Balance,${to}`).amount ==
-        (oldTokenStorage.get(`Balance,${to}`)?.amount ?? 0) + amount
+        (oldTokenStorage.get(`Balance,${to}`)?.amount ?? 0n) + amount
     )
 }
 
@@ -197,7 +197,7 @@ export function tokenTransferred(
     token: string,
     from: string,
     to: string,
-    amount: number
+    amount: bigint
 ): Condition {
     const oldTokenStorage = env.oldStorage(token).persistent()
     const tokenStorage = env.storage(token).persistent()
@@ -205,7 +205,7 @@ export function tokenTransferred(
         tokenStorage.get(`Balance,${from}`).amount ==
             oldTokenStorage.get(`Balance,${from}`)?.amount - amount,
         tokenStorage.get(`Balance,${to}`).amount ==
-            (oldTokenStorage.get(`Balance,${to}`)?.amount ?? 0) + amount
+            (oldTokenStorage.get(`Balance,${to}`)?.amount ?? 0n) + amount
     )
 }
 

--- a/solarkraft/test/e2e/verify_js_example.ts
+++ b/solarkraft/test/e2e/verify_js_example.ts
@@ -38,7 +38,7 @@ function tokenTransferred(
     token: string,
     from: string,
     to: string,
-    amount: number
+    amount: bigint
 ): Condition {
     const oldTokenStorage = env.oldStorage(token).persistent()
     const tokenStorage = env.storage(token).persistent()
@@ -46,7 +46,7 @@ function tokenTransferred(
         tokenStorage.get(`Balance,${from}`) ==
             oldTokenStorage.get(`Balance,${from}`) - amount,
         tokenStorage.get(`Balance,${to}`) ==
-            oldTokenStorage.get(`Balance,${to}`, 0) + amount
+            oldTokenStorage.get(`Balance,${to}`, 0n) + amount
     )
 }
 
@@ -59,12 +59,12 @@ enum TimeBoundKind {
 
 interface TimeBound {
     kind: TimeBoundKind
-    timestamp: number
+    timestamp: bigint
 }
 
 interface ClaimableBalance {
     token: string
-    amount: number
+    amount: bigint
     claimants: string[]
     time_bound: TimeBound
 }
@@ -75,7 +75,7 @@ class TimelockMonitor extends SolarkraftJsMonitor {
     deposit(
         from: string,
         token: string,
-        amount: number,
+        amount: bigint,
         claimants: string[],
         time_bound: TimeBound
     ) {

--- a/solarkraft/test/unit/verify_js.test.ts
+++ b/solarkraft/test/unit/verify_js.test.ts
@@ -69,15 +69,15 @@ describe('JavaScript/TypeScript monitor', () => {
             const env = {
                 oldStorage: (_tokenAddr: string) => ({
                     persistent: () =>
-                        Map([[`Balance,toAddress`, { amount: 50 }]]),
+                        Map([[`Balance,toAddress`, { amount: 50n }]]),
                 }),
                 storage: (_tokenAddr: string) => ({
                     persistent: () =>
-                        Map([[`Balance,toAddress`, { amount: 60 }]]),
+                        Map([[`Balance,toAddress`, { amount: 60n }]]),
                 }),
             } as unknown as Env
 
-            const condition = tokenReceived(env, 'token', 'toAddress', 10)
+            const condition = tokenReceived(env, 'token', 'toAddress', 10n)
             assert.isTrue(evaluateCondition(condition))
         })
 
@@ -85,15 +85,15 @@ describe('JavaScript/TypeScript monitor', () => {
             const env = {
                 oldStorage: (_token: string) => ({
                     persistent: () =>
-                        Map([[`Balance,toAddress`, { amount: 50 }]]),
+                        Map([[`Balance,toAddress`, { amount: 50n }]]),
                 }),
                 storage: (_token: string) => ({
                     persistent: () =>
-                        Map([[`Balance,toAddress`, { amount: 55 }]]),
+                        Map([[`Balance,toAddress`, { amount: 55n }]]),
                 }),
             } as unknown as Env
 
-            const condition = tokenReceived(env, 'token', 'toAddress', 10)
+            const condition = tokenReceived(env, 'token', 'toAddress', 10n)
             assert.isFalse(evaluateCondition(condition))
         })
 
@@ -104,11 +104,11 @@ describe('JavaScript/TypeScript monitor', () => {
                 }),
                 storage: (_token: string) => ({
                     persistent: () =>
-                        Map([[`Balance,toAddress`, { amount: 10 }]]),
+                        Map([[`Balance,toAddress`, { amount: 10n }]]),
                 }),
             } as unknown as Env
 
-            const condition = tokenReceived(env, 'token', 'toAddress', 10)
+            const condition = tokenReceived(env, 'token', 'toAddress', 10n)
             assert.isTrue(evaluateCondition(condition))
         })
 
@@ -118,11 +118,11 @@ describe('JavaScript/TypeScript monitor', () => {
                     persistent: () => Map([]),
                 }),
                 storage: (_token: string) => ({
-                    persistent: () => Map([[`Balance,toAddress`, 5]]),
+                    persistent: () => Map([[`Balance,toAddress`, 5n]]),
                 }),
             } as unknown as Env
 
-            const condition = tokenReceived(env, 'token', 'toAddress', 10)
+            const condition = tokenReceived(env, 'token', 'toAddress', 10n)
             assert.isFalse(evaluateCondition(condition))
         })
     })
@@ -134,15 +134,15 @@ describe('JavaScript/TypeScript monitor', () => {
                 oldStorage: (_tokenAddr: string) => ({
                     persistent: () =>
                         Map([
-                            [`Balance,fromAddress`, { amount: 100 }],
-                            [`Balance,toAddress`, { amount: 50 }],
+                            [`Balance,fromAddress`, { amount: 100n }],
+                            [`Balance,toAddress`, { amount: 50n }],
                         ]),
                 }),
                 storage: (_tokenAddr: string) => ({
                     persistent: () =>
                         Map([
-                            [`Balance,fromAddress`, { amount: 90 }],
-                            [`Balance,toAddress`, { amount: 60 }],
+                            [`Balance,fromAddress`, { amount: 90n }],
+                            [`Balance,toAddress`, { amount: 60n }],
                         ]),
                 }),
             } as unknown as Env
@@ -152,7 +152,7 @@ describe('JavaScript/TypeScript monitor', () => {
                 'token',
                 'fromAddress',
                 'toAddress',
-                10
+                10n
             )
             assert.isTrue(evaluateCondition(condition))
         })
@@ -162,15 +162,15 @@ describe('JavaScript/TypeScript monitor', () => {
                 oldStorage: (_token: string) => ({
                     persistent: () =>
                         Map([
-                            [`Balance,fromAddress`, { amount: 100 }],
-                            [`Balance,toAddress`, { amount: 50 }],
+                            [`Balance,fromAddress`, { amount: 100n }],
+                            [`Balance,toAddress`, { amount: 50n }],
                         ]),
                 }),
                 storage: (_token: string) => ({
                     persistent: () =>
                         Map([
-                            [`Balance,fromAddress`, { amount: 95 }],
-                            [`Balance,toAddress`, { amount: 55 }],
+                            [`Balance,fromAddress`, { amount: 95n }],
+                            [`Balance,toAddress`, { amount: 55n }],
                         ]),
                 }),
             } as unknown as Env
@@ -180,7 +180,7 @@ describe('JavaScript/TypeScript monitor', () => {
                 'token',
                 'fromAddress',
                 'toAddress',
-                10
+                10n
             )
             assert.isFalse(evaluateCondition(condition))
         })
@@ -189,13 +189,13 @@ describe('JavaScript/TypeScript monitor', () => {
             const env = {
                 oldStorage: (_token: string) => ({
                     persistent: () =>
-                        Map([[`Balance,fromAddress`, { amount: 100 }]]),
+                        Map([[`Balance,fromAddress`, { amount: 100n }]]),
                 }),
                 storage: (_token: string) => ({
                     persistent: () =>
                         Map([
-                            [`Balance,fromAddress`, { amount: 90 }],
-                            [`Balance,toAddress`, { amount: 10 }],
+                            [`Balance,fromAddress`, { amount: 90n }],
+                            [`Balance,toAddress`, { amount: 10n }],
                         ]),
                 }),
             } as unknown as Env
@@ -205,7 +205,7 @@ describe('JavaScript/TypeScript monitor', () => {
                 'token',
                 'fromAddress',
                 'toAddress',
-                10
+                10n
             )
             assert.isTrue(evaluateCondition(condition))
         })
@@ -214,13 +214,13 @@ describe('JavaScript/TypeScript monitor', () => {
             const env = {
                 oldStorage: (_token: string) => ({
                     persistent: () =>
-                        Map([[`Balance,toAddress`, { amount: 50 }]]),
+                        Map([[`Balance,toAddress`, { amount: 50n }]]),
                 }),
                 storage: (_token: string) => ({
                     persistent: () =>
                         Map([
-                            [`Balance,fromAddress`, { amount: -10 }],
-                            [`Balance,toAddress`, { amount: 60 }],
+                            [`Balance,fromAddress`, { amount: -10n }],
+                            [`Balance,toAddress`, { amount: 60n }],
                         ]),
                 }),
             } as unknown as Env
@@ -230,7 +230,7 @@ describe('JavaScript/TypeScript monitor', () => {
                 'token',
                 'fromAddress',
                 'toAddress',
-                10
+                10n
             )
             assert.isFalse(evaluateCondition(condition))
         })


### PR DESCRIPTION
To avoid mixing `number` and `bigint`, we should use bigint for all numerical contract data.

We previously lost them by writing JSON to disk, this rectifies it by instructing `JSONbigint` to always load numerical types as native bigint.