### PR TITLE
minimal TLA+ spec of the xycloans monitor

### DIFF
--- a/doc/case-studies/xycloans/MCxycloans_monitor.tla
+++ b/doc/case-studies/xycloans/MCxycloans_monitor.tla
@@ -83,8 +83,12 @@ Next ==
                 \/ update_fee_rewards([ env |-> env, call |-> UpdateFeeRewards(addr), status |-> success ])
             \* Propagate the new storage. For value generation, we go over all addresses, not subsets.
             /\ storage' = IF success THEN new_stor ELSE storage
-                /\ success => tx.env.old_storage = storage
+
+\* use this falsy invariant to generate examples of successful transactions
+NoSuccessInv ==
+    ~IsCreate(last_tx.call) => ~last_tx.status
 
 \* use this view to generate better test coverage
+\* apalache-mc check --max-error=10 --length=10 --inv=NoSuccessInv --view=View MCxycloans_monitor.tla
 View == <<last_tx.status, last_tx.call>>
 =========================================================================================

--- a/doc/case-studies/xycloans/MCxycloans_monitor.tla
+++ b/doc/case-studies/xycloans/MCxycloans_monitor.tla
@@ -1,0 +1,96 @@
+------------------------------- MODULE MCxycloans_monitor -------------------------------
+(*
+ * An instance of xycloans monitor for model checking and input generation.
+ *
+ * Igor Konnov, 2024
+ *)
+EXTENDS Integers, xycloans_types
+
+\* the set of all possible token amounts
+AMOUNTS == Nat
+\* the contract address for the XY Loans contract
+XYCLOANS == "xycloans"
+\* the token address
+XLM_TOKEN_SAC_TESTNET == "xlm-sac"
+
+\* the pool of addresses to draw the values from
+ADDR == { "alice", "bob", "eve", XLM_TOKEN_SAC_TESTNET, XYCLOANS }
+
+VARIABLES
+    \* @type: $tx;
+    last_tx,
+    \* @type: Str -> Int;
+    shares,
+    \* @type: Int;
+    total_shares,
+    \* @type: Int;
+    fee_per_share_universal
+
+INSTANCE xycloans_monitor
+
+Init ==
+    /\ last_tx = [
+            call |-> Create("any"),
+            status |-> TRUE,
+            env |-> [
+                current_contract_address |-> "any",
+                storage |-> [
+                    self_instance |-> [
+                        FeePerShareUniversal |-> 0,
+                        TokenId |-> ""
+                    ],
+                    self_persistent |-> [
+                        Balance |-> [ addr \in {} |-> 0 ],
+                        MaturedFeesParticular |-> [ addr \in {} |-> 0 ],
+                        FeePerShareParticular |-> [ addr \in {} |-> 0 ]
+                    ],
+                    token_persistent |-> [ Balance |-> [ addr \in {} |-> 0 ] ]
+                ],
+                old_storage |-> [
+                    self_instance |-> [
+                        FeePerShareUniversal |-> 0,
+                        TokenId |-> ""
+                    ],
+                    self_persistent |-> [
+                        Balance |-> [ addr \in {} |-> 0 ],
+                        MaturedFeesParticular |-> [ addr \in {} |-> 0 ],
+                        FeePerShareParticular |-> [ addr \in {} |-> 0 ]
+                    ],
+                    token_persistent |-> [ Balance |-> [ addr \in {} |-> 0 ] ]
+                ]
+            ]
+        ]
+    /\ shares = [ addr \in {} |-> 0 ]
+    /\ total_shares = 0
+    /\ fee_per_share_universal = 0
+
+Next ==
+    \* generate some values for the storage
+    \E fpsu \in AMOUNTS, tid \in { "", XLM_TOKEN_SAC_TESTNET }:
+      \E b, mfp, fpsp, tb \in [ ADDR -> AMOUNTS ]:
+        LET storage == [
+                self_instance |-> [ FeePerShareUniversal |-> fpsu, TokenId |-> tid ],
+                self_persistent |-> [ Balance |-> b, MaturedFeesParticular |-> mfp, FeePerShareParticular |-> fpsp ],
+                token_persistent |-> [ Balance |-> tb ]
+            ]
+            env == [
+                current_contract_address |-> XYCLOANS,
+                storage |-> storage,
+                old_storage |-> last_tx.env.storage
+            ]
+        IN
+        \E method \in { "initialize", "deposit", "borrow", "update_fee_rewards" }:
+            \E addr \in ADDR, amount \in AMOUNTS, success \in BOOLEAN:
+                LET call ==
+                    CASE method = "initialize" -> Initialize(XLM_TOKEN_SAC_TESTNET)
+                      [] method = "deposit" -> Deposit(addr, amount)
+                      [] method = "borrow" -> Borrow(addr, amount)
+                      [] method = "update_fee_rewards" -> UpdateFeeRewards(addr)
+                IN
+                LET tx == [ env |-> env, call |-> call, status |-> success ] IN
+                \/ initialize(tx)
+                \/ deposit(tx)
+                \/ borrow(tx)
+                \/ update_fee_rewards(tx)
+
+=========================================================================================

--- a/doc/case-studies/xycloans/MCxycloans_monitor.tla
+++ b/doc/case-studies/xycloans/MCxycloans_monitor.tla
@@ -39,18 +39,18 @@ Init ==
             TokenId |-> ""
         ],
         self_persistent |-> [
-            Balance |-> [ addr \in {} |-> 0 ],
-            MaturedFeesParticular |-> [ addr \in {} |-> 0 ],
-            FeePerShareParticular |-> [ addr \in {} |-> 0 ]
+            Balance |-> [ addr \in ADDR |-> 0 ],
+            MaturedFeesParticular |-> [ addr \in ADDR |-> 0 ],
+            FeePerShareParticular |-> [ addr \in ADDR |-> 0 ]
         ],
         token_persistent |-> [ Balance |-> [ addr \in {} |-> 0 ] ]
     ]
     IN
     /\ last_tx = [
-            call |-> Create("any"),
+            call |-> Create(XYCLOANS),
             status |-> TRUE,
             env |-> [
-                current_contract_address |-> "any",
+                current_contract_address |-> XYCLOANS,
                 storage |-> init_stor,
                 old_storage |-> init_stor
             ]

--- a/doc/case-studies/xycloans/MCxycloans_monitor.tla
+++ b/doc/case-studies/xycloans/MCxycloans_monitor.tla
@@ -81,8 +81,7 @@ Next ==
                 \/ deposit([ env |-> env, call |-> Deposit(addr, amount), status |-> success ])
                 \/ borrow([ env |-> env, call |-> Borrow(addr, amount), status |-> success ])
                 \/ update_fee_rewards([ env |-> env, call |-> UpdateFeeRewards(addr), status |-> success ])
-            \* propagate the new storage
-            \* TODO: new_stor may contain updates to a subset of addresses
+            \* Propagate the new storage. For value generation, we go over all addresses, not subsets.
             /\ storage' = IF success THEN new_stor ELSE storage
                 /\ success => tx.env.old_storage = storage
 

--- a/doc/case-studies/xycloans/MCxycloans_monitor.tla
+++ b/doc/case-studies/xycloans/MCxycloans_monitor.tla
@@ -43,7 +43,7 @@ Init ==
             MaturedFeesParticular |-> [ addr \in ADDR |-> 0 ],
             FeePerShareParticular |-> [ addr \in ADDR |-> 0 ]
         ],
-        token_persistent |-> [ Balance |-> [ addr \in {} |-> 0 ] ]
+        token_persistent |-> [ Balance |-> [ addr \in ADDR |-> 0 ] ]
     ]
     IN
     /\ last_tx = [
@@ -84,11 +84,15 @@ Next ==
             \* Propagate the new storage. For value generation, we go over all addresses, not subsets.
             /\ storage' = IF success THEN new_stor ELSE storage
 
+\* restrict the executions to the successful transactions
+NextOk ==
+    Next /\ last_tx'.status
+
 \* use this falsy invariant to generate examples of successful transactions
 NoSuccessInv ==
     ~IsCreate(last_tx.call) => ~last_tx.status
 
 \* use this view to generate better test coverage
 \* apalache-mc check --max-error=10 --length=10 --inv=NoSuccessInv --view=View MCxycloans_monitor.tla
-View == <<last_tx.status, last_tx.call>>
+View == <<last_tx.status, VariantTag(last_tx.call)>>
 =========================================================================================

--- a/doc/case-studies/xycloans/MCxycloans_monitor.tla
+++ b/doc/case-studies/xycloans/MCxycloans_monitor.tla
@@ -46,8 +46,13 @@ Init ==
         token_persistent |-> [ Balance |-> [ addr \in ADDR |-> 0 ] ]
     ]
     IN
+    \* initialize the monitor
+    /\ shares = [ addr \in {} |-> 0 ]
+    /\ total_shares = 0
+    /\ fee_per_share_universal = 0
+    \* initialize the contract state that we model
     /\ last_tx = [
-            call |-> Create(XYCLOANS),
+            call |-> Constructor(XYCLOANS),
             status |-> TRUE,
             env |-> [
                 current_contract_address |-> XYCLOANS,
@@ -55,9 +60,6 @@ Init ==
                 old_storage |-> init_stor
             ]
         ]
-    /\ shares = [ addr \in {} |-> 0 ]
-    /\ total_shares = 0
-    /\ fee_per_share_universal = 0
     /\ storage = init_stor
 
 Next ==
@@ -94,7 +96,7 @@ NextOk ==
 
 \* use this falsy invariant to generate examples of successful transactions
 NoSuccessInv ==
-    ~IsCreate(last_tx.call) => ~last_tx.status
+    ~IsConstructor(last_tx.call) => ~last_tx.status
 
 \* use this view to generate better test coverage
 \* apalache-mc check --max-error=10 --length=10 --inv=NoSuccessInv --view=View MCxycloans_monitor.tla

--- a/doc/case-studies/xycloans/xycloans_monitor.tla
+++ b/doc/case-studies/xycloans/xycloans_monitor.tla
@@ -130,43 +130,6 @@ update_fee_rewards(tx) ==
     /\ expected_reward = actual_reward
     \* update the monitor state
     /\ last_tx' = tx
-    /\ UNCHANGED <<shares, shares, fee_per_share_universal>>
-
-(* Actions that we use for model checking, not to monitoring *)
-Init ==
-    /\ last_tx = [
-            call |-> Create("any"),
-            status |-> TRUE,
-            env |-> [
-                current_contract_address |-> "any",
-                storage |-> [
-                    self_instance |-> [
-                        FeePerShareUniversal |-> 0,
-                        TokenId |-> ""
-                    ],
-                    self_persistent |-> [
-                        Balance |-> [ addr \in {} |-> 0 ],
-                        MaturedFeesParticular |-> [ addr \in {} |-> 0 ],
-                        FeePerShareParticular |-> [ addr \in {} |-> 0 ]
-                    ],
-                    token_persistent |-> [ Balance |-> [ addr \in {} |-> 0 ] ]
-                ],
-                old_storage |-> [
-                    self_instance |-> [
-                        FeePerShareUniversal |-> 0,
-                        TokenId |-> ""
-                    ],
-                    self_persistent |-> [
-                        Balance |-> [ addr \in {} |-> 0 ],
-                        MaturedFeesParticular |-> [ addr \in {} |-> 0 ],
-                        FeePerShareParticular |-> [ addr \in {} |-> 0 ]
-                    ],
-                    token_persistent |-> [ Balance |-> [ addr \in {} |-> 0 ] ]
-                ]
-            ]
-        ]
-    /\ shares = [ addr \in {} |-> 0 ]
-    /\ total_shares = 0
-    /\ fee_per_share_universal = 0
+    /\ UNCHANGED <<shares, total_shares, fee_per_share_universal>>
 
 =============================================================================

--- a/doc/case-studies/xycloans/xycloans_monitor.tla
+++ b/doc/case-studies/xycloans/xycloans_monitor.tla
@@ -58,7 +58,7 @@ old_token_balance(env, a) == get_or_else(env.old_storage.self_persistent.Balance
 initialize(tx) ==
     LET call == AsInitialize(tx.call) IN
     /\ IsInitialize(tx.call)
-    /\ reverts_if(tx, tx.env.storage.self_instance.TokenId /= "")
+    /\ reverts_if(tx, tx.env.old_storage.self_instance.TokenId /= "")
     /\ succeeds_if(tx, call.token = XLM_TOKEN_SAC_TESTNET)
     /\ succeeds_if(tx, tx.env.storage.self_instance.TokenId = call.token)
     /\ last_tx' = tx

--- a/doc/case-studies/xycloans/xycloans_monitor.tla
+++ b/doc/case-studies/xycloans/xycloans_monitor.tla
@@ -1,0 +1,172 @@
+-------------------------- MODULE xycloans_monitor --------------------------
+(*
+ * A monitor for the XY Loans contract to detect the known issue.
+ *
+ * This is a manual translation of the Typescript monitor from
+ * verify_js_examples_xycloans.ts. Our goal is to produce a simple and readable
+ * TLA+ specification that is used to monitor existing transactions and
+ * generate new transactions, e.g., from the current state.
+ *
+ * After receiving feedback from the users, we would think about automation.
+ *
+ * Igor Konnov, 2024
+ *)
+
+EXTENDS Integers, xycloans_types
+
+STROOP == 10000000
+
+CONSTANT
+    \* The token address for the XY Loans contract.
+    \* @type: Str;
+    XLM_TOKEN_SAC_TESTNET
+
+(* The internal state of our monitor (not of the contract) *)
+VARIABLES
+    \* The last monitored transaction.
+    \* @type: $tx;
+    last_tx,
+    \* Shares per address.
+    \* @type: Str -> Int;
+    shares,
+    \* The sum over all shares.
+    \* @type: Int;
+    total_shares,
+    \* Fee per share for the entire pool, in stroops.
+    \* @type: Int;
+    fee_per_share_universal
+
+(* The core logic of the monitor for the contract data *)
+
+\* @type: ($tx, Bool) => Bool;
+reverts_if(tx, cond) == cond => ~tx.status
+\* @type: ($tx, Bool) => Bool;
+succeeds_if(tx, cond) == cond => tx.status
+\* @type: (Str -> a, Str, a) => a;
+get_or_else(map, key, default) ==
+    IF key \in DOMAIN map THEN map[key] ELSE default
+\* integer division with rounding up
+div_ceil(a, b) == a + (b - 1) \div b
+\* integer division with rounding down
+div_floor(a, b) == a \div b
+\* @type: ($env, Str) => Int;
+token_balance(env, a) == get_or_else(env.storage.self_persistent.Balance, a, 0)
+\* @type: ($env, Str) => Int;
+old_token_balance(env, a) == get_or_else(env.old_storage.self_persistent.Balance, a, 0)
+
+\* @type: $tx => Bool;
+initialize(tx) ==
+    LET call == AsInitialize(tx.call) IN
+    /\ IsInitialize(tx.call)
+    /\ reverts_if(tx, tx.env.storage.self_instance.TokenId /= "")
+    /\ succeeds_if(tx, call.token = XLM_TOKEN_SAC_TESTNET)
+    /\ succeeds_if(tx, tx.env.storage.self_instance.TokenId = call.token)
+    /\ last_tx' = tx
+    /\ shares' = [ addr \in {} |-> 0 ]
+    /\ total_shares' = 0
+    /\ fee_per_share_universal' = 0    
+
+\* @type: $tx => Bool;
+deposit(tx) ==
+    LET call == AsDeposit(tx.call)
+        token == tx.env.storage.self_instance.TokenId
+        new_shares == [ shares EXCEPT ![call.from] = @ + call.amount ]
+    IN
+    /\ IsDeposit(tx.call)
+    \* the pool has received `amount` tokens
+    /\  LET a == tx.env.current_contract_address IN
+        succeeds_if(tx, token_balance(tx.env, a) = old_token_balance(tx.env, a) + call.amount)
+    \* `from` received `amount` shares
+    /\  LET b == get_or_else(tx.env.storage.self_persistent.Balance, call.from, 0)
+            old_b == get_or_else(tx.env.old_storage.self_persistent.Balance, call.from, 0)
+        IN
+        /\ succeeds_if(tx, new_shares[call.from] = b)
+        /\ succeeds_if(tx, b = old_b + call.amount)
+    \* update the monitor state
+    /\ last_tx' = tx
+    /\ shares' = new_shares
+    /\ total_shares' = total_shares + call.amount
+    /\ UNCHANGED fee_per_share_universal
+
+\* @type: $tx => Bool;
+borrow(tx) ==
+    LET call == AsBorrow(tx.call)
+        expected_fee == div_ceil(call.amount * STROOP, 12500000000)
+        expected_fee_per_share_universal ==
+            tx.env.old_storage.self_instance.FeePerShareUniversal
+                + div_floor(expected_fee * STROOP, total_shares)
+    IN
+    /\ IsBorrow(tx.call)
+    \* `FeePerShareUniversal` has been updated correctly
+    /\ succeeds_if(tx,
+           expected_fee_per_share_universal = tx.env.storage.self_instance.FeePerShareUniversal)
+    \* the receiver paid the expected fee to the pool
+    /\ succeeds_if(tx, old_token_balance(tx.env, call.receiver_id) >= call.amount)
+    /\ LET a == call.receiver_id IN
+       succeeds_if(tx, token_balance(tx.env, a) = old_token_balance(tx.env, a) - call.amount)
+    /\ LET a == tx.env.current_contract_address IN
+       succeeds_if(tx, token_balance(tx.env, a) = old_token_balance(tx.env, a) + call.amount)
+    \* update the monitor state
+    /\ last_tx' = tx
+    \* we update the fee per share to compute rewards later
+    /\ fee_per_share_universal' = expected_fee_per_share_universal
+    /\ UNCHANGED <<shares, total_shares>>
+
+\* @type: $tx => Bool;
+update_fee_rewards(tx) ==
+    LET call == AsUpdateFeeRewards(tx.call)
+        fees_not_yet_considered ==
+            fee_per_share_universal - get_or_else(tx.env.old_storage.self_persistent.FeePerShareParticular, call.addr, 0)
+        expected_reward == div_floor(get_or_else(shares, call.addr, 0) * fees_not_yet_considered, STROOP)
+        mf == get_or_else(tx.env.storage.self_persistent.MaturedFeesParticular, call.addr, 0)
+        old_mf == get_or_else(tx.env.old_storage.self_persistent.MaturedFeesParticular, call.addr, 0)
+        actual_reward == mf - old_mf
+    IN
+    /\ IsUpdateFeeRewards(tx.call)
+    \* fee per share for `addr` is bumped to the universal fee per share
+    /\  LET fee == get_or_else(tx.env.storage.self_persistent.FeePerShareParticular, call.addr, 0) IN
+        succeeds_if(tx, fee = fee_per_share_universal)
+    \* delta of matured rewards for `addr` have been added
+    /\ expected_reward = actual_reward
+    \* update the monitor state
+    /\ last_tx' = tx
+    /\ UNCHANGED <<shares, shares, fee_per_share_universal>>
+
+(* Actions that we use for model checking, not to monitoring *)
+Init ==
+    /\ last_tx = [
+            call |-> Create("any"),
+            status |-> TRUE,
+            env |-> [
+                current_contract_address |-> "any",
+                storage |-> [
+                    self_instance |-> [
+                        FeePerShareUniversal |-> 0,
+                        TokenId |-> ""
+                    ],
+                    self_persistent |-> [
+                        Balance |-> [ addr \in {} |-> 0 ],
+                        MaturedFeesParticular |-> [ addr \in {} |-> 0 ],
+                        FeePerShareParticular |-> [ addr \in {} |-> 0 ]
+                    ],
+                    token_persistent |-> [ Balance |-> [ addr \in {} |-> 0 ] ]
+                ],
+                old_storage |-> [
+                    self_instance |-> [
+                        FeePerShareUniversal |-> 0,
+                        TokenId |-> ""
+                    ],
+                    self_persistent |-> [
+                        Balance |-> [ addr \in {} |-> 0 ],
+                        MaturedFeesParticular |-> [ addr \in {} |-> 0 ],
+                        FeePerShareParticular |-> [ addr \in {} |-> 0 ]
+                    ],
+                    token_persistent |-> [ Balance |-> [ addr \in {} |-> 0 ] ]
+                ]
+            ]
+        ]
+    /\ shares = [ addr \in {} |-> 0 ]
+    /\ total_shares = 0
+    /\ fee_per_share_universal = 0
+
+=============================================================================

--- a/doc/case-studies/xycloans/xycloans_monitor.tla
+++ b/doc/case-studies/xycloans/xycloans_monitor.tla
@@ -23,9 +23,6 @@ CONSTANT
 
 (* The internal state of our monitor (not of the contract) *)
 VARIABLES
-    \* The last monitored transaction.
-    \* @type: $tx;
-    last_tx,
     \* Shares per address.
     \* @type: Str -> Int;
     shares,
@@ -66,7 +63,6 @@ initialize(tx) ==
     \* these conditions are not required by a monitor, but needed to avoid spurious generated values
     /\ succeeds_with(tx,
         tx.env.storage.self_persistent = tx.env.old_storage.self_persistent)
-    /\ last_tx' = tx
     /\ shares' = [ addr \in {} |-> 0 ]
     /\ total_shares' = 0
     /\ fee_per_share_universal' = 0    
@@ -94,7 +90,6 @@ deposit(tx) ==
             /\ tx.env.storage.self_persistent.Balance[other] = tx.env.old_storage.self_persistent.Balance[other])
     /\ succeeds_with(tx, call.amount > 0)
     \* update the monitor state
-    /\ last_tx' = tx
     /\ shares' = new_shares
     /\ total_shares' = total_shares + call.amount
     /\ UNCHANGED fee_per_share_universal
@@ -121,7 +116,6 @@ borrow(tx) ==
     /\ succeeds_with(tx, tx.env.storage.self_persistent = tx.env.old_storage.self_persistent)
     /\ succeeds_with(tx, call.amount > 0)
     \* update the monitor state
-    /\ last_tx' = tx
     \* we update the fee per share to compute rewards later
     /\ fee_per_share_universal' = expected_fee_per_share_universal
     /\ UNCHANGED <<shares, total_shares>>
@@ -146,7 +140,6 @@ update_fee_rewards(tx) ==
     /\ succeeds_with(tx,
         tx.env.storage.self_persistent.Balance = tx.env.old_storage.self_persistent.Balance)
     \* update the monitor state
-    /\ last_tx' = tx
     /\ UNCHANGED <<shares, total_shares, fee_per_share_universal>>
 
 =============================================================================

--- a/doc/case-studies/xycloans/xycloans_types.tla
+++ b/doc/case-studies/xycloans/xycloans_types.tla
@@ -3,7 +3,7 @@ EXTENDS Variants
 
 (*
     The relevant parts of the storage that is accessed by the contract.
-    Note that the storage is partial. At any point in time, we only have
+    Note that our view of the storage is partial: at any point in time, we only have
     access to the parts of the storage that are touched by the contract.
 
     @typeAlias: storage = {
@@ -21,7 +21,7 @@ EXTENDS Variants
         }
     };
 
-    The environment of the XY Loans contract that should be
+    The environment of the xycLoans contract that should be
     produced by Solarkraft from the transaction metadata:
 
     @typeAlias: env = {

--- a/doc/case-studies/xycloans/xycloans_types.tla
+++ b/doc/case-studies/xycloans/xycloans_types.tla
@@ -1,0 +1,85 @@
+--------------------------------- MODULE xycloans_types -----------------------
+EXTENDS Variant
+
+(*
+    The relevant parts of the storage that is accessed by the contract.
+    Note that the storage is partial. At any point in time, we only have
+    access to the parts of the storage that are touched by the contract.
+
+    @typeAlias: storage = {
+        self_instance: {
+            FeePerShareUniversal: Int,
+            TokenId: Str
+        },
+        self_persistent: {
+            Balance: Str -> Int,
+            MaturedFeesParticular: Str -> Int,
+            FeePerShareParticular: Str -> Int
+        },
+        token_persistent: {
+            Balance: Str -> Int
+        }
+    };
+
+    The environment of the XY Loans contract that should be
+    produced by Solarkraft from the transaction metadata:
+
+    @typeAlias: env = {
+        current_contract_address: Str,
+        storage: $storage,
+        old_storage: $storage
+    };
+
+    An external contract call:
+
+    @typeAlias: call =
+          Create({ addr: Str })
+        | Initialize({ token: Str })
+        | Deposit({ from: Str, amount: Int })
+        | Borrow({ receiver_id: Str, amount: Int })
+        | UpdateFeeRewards({ addr: Str})
+    ;
+
+    Finally, a transaction is:
+
+    @typeAlias: tx = {
+        env: $env,
+        call: $call,
+        status: Bool
+    };
+ *)
+xycloans_typedefs == TRUE
+
+(* Boilerplate definitions for the method types (mostly generated with copilot) *)
+
+\* @type: Str => $call;
+Create(addr) == Variant("Create", [ addr |-> addr ])
+\* @type: Str => $call;
+Initialize(token) == Variant("Initialize", [ token |-> token ])
+\* @type: $call => Bool;
+IsInitialize(call) == VariantTag(call) = "Initialize"
+\* @type: $call => { token: Str };
+AsInitialize(call) == VariantGetUnsafe("Initialize", call)
+
+\* @type: (Str, Int) => $call;
+Deposit(from, amount) == Variant("Deposit", [ from |-> from, amount |-> amount ])
+\* @type: $call => Bool;
+IsDeposit(call) == VariantTag(call) = "Deposit"
+\* @type: $call => { from: Str, amount: Int };
+AsDeposit(call) == VariantGetUnsafe("Deposit", call)
+
+\* @type: (Str, Int) => $call;
+Borrow(receiver_id, amount) == Variant("Borrow", [ receiver_id |-> receiver_id, amount |-> amount ])
+\* @type: $call => Bool;
+IsBorrow(call) == VariantTag(call) = "Borrow"
+\* @type: $call => { receiver_id: Str, amount: Int };
+AsBorrow(call) == VariantGetUnsafe("Borrow", call)
+
+\* @type: Str => $call;
+UpdateFeeRewards(addr) == Variant("UpdateFeeRewards", [ addr |-> addr ])
+\* @type: $call => Bool;
+IsUpdateFeeRewards(call) == VariantTag(call) = "UpdateFeeRewards"
+\* @type: $call => { addr: Str };
+AsUpdateFeeRewards(call) == VariantGetUnsafe("UpdateFeeRewards", call)
+
+===============================================================================

--- a/doc/case-studies/xycloans/xycloans_types.tla
+++ b/doc/case-studies/xycloans/xycloans_types.tla
@@ -33,7 +33,7 @@ EXTENDS Variants
     An external contract call:
 
     @typeAlias: call =
-          Create({ addr: Str })
+          Constructor({ addr: Str })
         | Initialize({ token: Str })
         | Deposit({ from: Str, amount: Int })
         | Borrow({ receiver_id: Str, amount: Int })
@@ -53,9 +53,9 @@ xycloans_typedefs == TRUE
 (* Boilerplate definitions for the method types (mostly generated with copilot) *)
 
 \* @type: Str => $call;
-Create(addr) == Variant("Create", [ addr |-> addr ])
+Constructor(addr) == Variant("Constructor", [ addr |-> addr ])
 \* @type: $call => Bool;
-IsCreate(call) == VariantTag(call) = "Create"
+IsConstructor(call) == VariantTag(call) = "Constructor"
 \* @type: Str => $call;
 Initialize(token) == Variant("Initialize", [ token |-> token ])
 \* @type: $call => Bool;

--- a/doc/case-studies/xycloans/xycloans_types.tla
+++ b/doc/case-studies/xycloans/xycloans_types.tla
@@ -54,6 +54,8 @@ xycloans_typedefs == TRUE
 
 \* @type: Str => $call;
 Create(addr) == Variant("Create", [ addr |-> addr ])
+\* @type: $call => Bool;
+IsCreate(call) == VariantTag(call) = "Create"
 \* @type: Str => $call;
 Initialize(token) == Variant("Initialize", [ token |-> token ])
 \* @type: $call => Bool;

--- a/doc/case-studies/xycloans/xycloans_types.tla
+++ b/doc/case-studies/xycloans/xycloans_types.tla
@@ -1,5 +1,5 @@
 --------------------------------- MODULE xycloans_types -----------------------
-EXTENDS Variant
+EXTENDS Variants
 
 (*
     The relevant parts of the storage that is accessed by the contract.


### PR DESCRIPTION
This is basically the TLA+ specification after `verify_js_example_xycloans.ts`. Apalache produces examples for `MCxycloans_monitor.tla`. However, we probably need more constraints in the spec, as the environment gets a complete update every time. We have to figure out how to produce meaningful examples.