### PR TITLE
fixing the CI + workflow for deploying contracts to testnet

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,29 +56,23 @@ jobs:
         toolchain:
           - stable
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: rustup target add wasm32-unknown-unknown
-      - uses: stellar/binaries@v22
+      # see: https://github.com/stellar/soroban-examples/blob/main/.github/workflows/rust.yml
+      - uses: stellar/actions/rust-cache@main
+      # pin the rust version: https://github.com/stellar/rs-soroban-sdk/pull/1353
+      - run: |
+          rustup default 1.81.0
+          rustup update
+      - run: cargo version
+      - uses: stellar/stellar-cli@main
         with:
-          name: soroban-cli
-          version: '20.0.0-rc.4.1'
-          # version 21 is not available in stellar/binaries yet
-          #version: '21.0.0-preview.1'
+          version: 22.0.0
+
+      - run: stellar --version
+
       - name: build
         run: cd ContractExamples && cargo build --verbose --workspace --exclude "soroban-timelock-contract" --exclude "soroban-token-contract"
       - name: unit tests
         run: cd ContractExamples && cargo test --verbose --workspace --exclude "soroban-timelock-contract" --exclude "soroban-token-contract"
-
-      # v21 is not available in stellar/binaries yet
-      #- name: populating Setter
-      #  run: |
-      #    soroban network add \
-      #      --global testnet \
-      #      --rpc-url https://soroban-testnet.stellar.org:443 \
-      #      --network-passphrase "Test SDF Network ; September 2015"
-      #    soroban keys generate --global alice --network testnet
-      #    cd ContractExamples
-      #    ./scripts/setter-populate.sh

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -1,0 +1,25 @@
+name: Deployment to testnet
+
+on:
+  workflow_dispatch
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      
+      - name: Install Soroban
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo install --locked stellar-cli --version v22.0.0 --features opt
+
+      - name: Generate Soroban keys
+        run: |
+          stellar keys generate --global alice --network testnet --fund
+          stellar keys generate --global bob --network testnet --fund
+          stellar keys generate --global admin --network testnet --fund

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -22,7 +22,7 @@ jobs:
       - run: cargo version
       - uses: stellar/stellar-cli@main
         with:
-          version: 22.0.1
+          version: 22.0.0
 
       - run: stellar --version
 

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -19,7 +19,8 @@ jobs:
       - run: cargo version
       - uses: stellar/stellar-cli@main
         with:
-          version: 22.0.0
+          version: 21.5.3
+          #version: 22.0.0
 
       - run: stellar --version
 

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           stellar keys generate --global alice --network testnet --fund
           stellar keys generate --global bob --network testnet --fund
+          stellar keys generate --global admin --network testnet --fund
 
       - name: Build contract examples
         run: |

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -6,7 +6,7 @@ on:
     # This cron expression triggers the workflow at 8:00 UTC every day
     - cron: "8 0 * * *"
   # uncomment to debug in a PR
-  pull_request:
+  #pull_request:
  
 jobs:
   build-and-deploy:

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -10,18 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-node@v3
+      # see: https://github.com/stellar/soroban-examples/blob/main/.github/workflows/rust.yml
+      - uses: stellar/actions/rust-cache@main
+      - run: rustup update
+      - run: cargo version
+      - run: rustup target add wasm32-unknown-unknown
+      - uses: stellar/stellar-cli@v22
         with:
-          node-version: '16'
-      
-      - name: Install Soroban
-        run: |
-          rustup target add wasm32-unknown-unknown
-          cargo install --locked stellar-cli --version 22.0.0 --features opt
+          version: 22.0.0
 
       - name: Generate Soroban keys
         run: |
           stellar keys generate --global alice --network testnet --fund
           stellar keys generate --global bob --network testnet --fund
-          stellar keys generate --global admin --network testnet --fund
+
+      #- uses: actions/setup-node@v3
+      #  with:
+      #    node-version: '16'
+      #   stellar keys generate --global admin --network testnet --fund

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -17,10 +17,11 @@ jobs:
       - uses: stellar/actions/rust-cache@main
       - run: rustup update
       - run: cargo version
-      - run: rustup target add wasm32-unknown-unknown
       - uses: stellar/stellar-cli@main
         with:
           version: 22.0.0
+
+      - run: stellar --version
 
       - name: Generate Soroban keys
         run: |
@@ -30,6 +31,7 @@ jobs:
       - name: Build contract examples
         run: |
           cd ContractExamples
+          rustup target add wasm32-unknown-unknown
           cargo build --release --all
 
       - name: Deploy alert

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -60,8 +60,3 @@ jobs:
         run: |
           cd ContractExamples
           ./scripts/xycloans-populate.sh
-
-      #- uses: actions/setup-node@v3
-      #  with:
-      #    node-version: '16'
-      #   stellar keys generate --global admin --network testnet --fund

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -1,8 +1,10 @@
 name: Deployment to testnet
 
 on:
-  workflow_dispatch
-
+  workflow_dispatch:
+  # TODO: comment out after debugging in the draft PR
+  pull_request:
+ 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Update submodules
+        run: |
+          git submodule update --init --recursive
       # see: https://github.com/stellar/soroban-examples/blob/main/.github/workflows/rust.yml
       - uses: stellar/actions/rust-cache@main
       - run: rustup update
@@ -23,6 +26,16 @@ jobs:
         run: |
           stellar keys generate --global alice --network testnet --fund
           stellar keys generate --global bob --network testnet --fund
+
+      - name: Build contract examples
+        run: |
+          cd ContractExamples
+          cargo build --release --all
+
+      - name: Deploy alert
+        run: |
+          cd ContractExamples
+          ./scripts/alert-deploy.sh
 
       #- uses: actions/setup-node@v3
       #  with:

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -19,8 +19,7 @@ jobs:
       - run: cargo version
       - uses: stellar/stellar-cli@main
         with:
-          version: 21.5.3
-          #version: 22.0.0
+          version: 22.0.0
 
       - run: stellar --version
 

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: stellar/actions/rust-cache@main
       # pin the rust version: https://github.com/stellar/rs-soroban-sdk/pull/1353
       - run: |
-          rustup default 1.82.0
+          rustup default 1.81.0
           rustup update
       - run: cargo version
       - uses: stellar/stellar-cli@main

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Soroban
         run: |
           rustup target add wasm32-unknown-unknown
-          cargo install --locked stellar-cli --version v22.0.0 --features opt
+          cargo install --locked stellar-cli --version 22.0.0 --features opt
 
       - name: Generate Soroban keys
         run: |

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Update submodules
-        run: |
-          git submodule update --init --recursive
+        with:
+          submodules: true
       # see: https://github.com/stellar/soroban-examples/blob/main/.github/workflows/rust.yml
       - uses: stellar/actions/rust-cache@main
       # pin the rust version: https://github.com/stellar/rs-soroban-sdk/pull/1353

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -6,7 +6,7 @@ on:
     # This cron expression triggers the workflow at 8:00 UTC every day
     - cron: "8 0 * * *"
   # uncomment to debug in a PR
-  #pull_request:
+  pull_request:
  
 jobs:
   build-and-deploy:

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -15,7 +15,7 @@ jobs:
       - run: rustup update
       - run: cargo version
       - run: rustup target add wasm32-unknown-unknown
-      - uses: stellar/stellar-cli@v22
+      - uses: stellar/stellar-cli@main
         with:
           version: 22.0.0
 

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -39,15 +39,15 @@ jobs:
           cd ContractExamples
           ./scripts/alert-deploy.sh
 
-      - name: Deploy timelock
-        run: |
-          cd ContractExamples
-          ./scripts/prepare-timelock.sh
-
       - name: Deploy setter
         run: |
           cd ContractExamples
           ./scripts/setter-populate.sh
+
+      - name: Deploy timelock
+        run: |
+          cd ContractExamples
+          ./scripts/prepare-timelock.sh
 
       #- uses: actions/setup-node@v3
       #  with:

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -22,7 +22,7 @@ jobs:
       - run: cargo version
       - uses: stellar/stellar-cli@main
         with:
-          version: 22.0.0
+          version: 22.0.1
 
       - run: stellar --version
 

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -37,6 +37,16 @@ jobs:
           cd ContractExamples
           ./scripts/alert-deploy.sh
 
+      - name: Deploy timelock
+        run: |
+          cd ContractExamples
+          ./scripts/prepare-timelock.sh
+
+      - name: Deploy setter
+        run: |
+          cd ContractExamples
+          ./scripts/setter-populate.sh
+
       #- uses: actions/setup-node@v3
       #  with:
       #    node-version: '16'

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -2,8 +2,11 @@ name: Deployment to testnet
 
 on:
   workflow_dispatch:
-  # TODO: comment out after debugging in the draft PR
-  pull_request:
+  schedule:
+    # This cron expression triggers the workflow at 8:00 UTC every day
+    - cron: "8 0 * * *"
+  # uncomment to debug in a PR
+  #pull_request:
  
 jobs:
   build-and-deploy:

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -53,6 +53,11 @@ jobs:
           cd ContractExamples
           ./scripts/prepare-timelock.sh
 
+      - name: Deploy xycloans
+        run: |
+          cd ContractExamples
+          ./scripts/xycloans-populate.sh
+
       #- uses: actions/setup-node@v3
       #  with:
       #    node-version: '16'

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -15,7 +15,10 @@ jobs:
           git submodule update --init --recursive
       # see: https://github.com/stellar/soroban-examples/blob/main/.github/workflows/rust.yml
       - uses: stellar/actions/rust-cache@main
-      - run: rustup update
+      # pin the rust version: https://github.com/stellar/rs-soroban-sdk/pull/1353
+      - run: |
+          rustup default 1.82.0
+          rustup update
       - run: cargo version
       - uses: stellar/stellar-cli@main
         with:

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -32,7 +32,8 @@ jobs:
         run: |
           cd ContractExamples
           rustup target add wasm32-unknown-unknown
-          cargo build --release --all
+          # it's important to disable reference types, otherwise we get deployment errors
+          RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release
 
       - name: Deploy alert
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "ContractExamples/soroban-examples"]
 	path = ContractExamples/soroban-examples
 	url = https://github.com/stellar/soroban-examples
+    branch = v20.2.0
 [submodule "ContractExamples/xycloans"]
 	path = ContractExamples/xycloans
 	url = https://github.com/xycloo/xycloans.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "ContractExamples/soroban-examples"]
 	path = ContractExamples/soroban-examples
 	url = https://github.com/stellar/soroban-examples
-    branch = v20.2.0
+    branch = v21.6.0
 [submodule "ContractExamples/xycloans"]
 	path = ContractExamples/xycloans
 	url = https://github.com/xycloo/xycloans.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "ContractExamples/xycloans"]
 	path = ContractExamples/xycloans
 	url = https://github.com/xycloo/xycloans.git
+	branch = b26e0124ab0b84c1be25c636492671f106653f09

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "ContractExamples/soroban-examples"]
 	path = ContractExamples/soroban-examples
 	url = https://github.com/stellar/soroban-examples
-    branch = v21.6.0
 [submodule "ContractExamples/xycloans"]
 	path = ContractExamples/xycloans
 	url = https://github.com/xycloo/xycloans.git

--- a/ContractExamples/.cargo/config.toml
+++ b/ContractExamples/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustflags = ["--cfg", "target_family=\"wasm\""]
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+bulk-memory"]

--- a/ContractExamples/.cargo/config.toml
+++ b/ContractExamples/.cargo/config.toml
@@ -1,5 +1,2 @@
-[build]
-rustflags = ["--cfg", "target_family=\"wasm\""]
-
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "target-feature=+bulk-memory"]

--- a/ContractExamples/.cargo/config.toml
+++ b/ContractExamples/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "target-feature=+bulk-memory"]

--- a/ContractExamples/Cargo.toml
+++ b/ContractExamples/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "22.0.0-rc.3"
+version = "22.0.0-rc.3.1"
 edition = "2021"
 
 [workspace.dependencies]

--- a/ContractExamples/Cargo.toml
+++ b/ContractExamples/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 
 [workspace.dependencies]
 soroban-sdk = { version = "22.0.0-rc.3.1" }
-soroban-token-sdk = { version = "22.0.0-rc.3.1" }
 
 [profile.release]
 opt-level = "z"

--- a/ContractExamples/Cargo.toml
+++ b/ContractExamples/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "21.6.0"
+soroban-sdk = "22.0.0-rc.3"
 
 [profile.release]
 opt-level = "z"

--- a/ContractExamples/Cargo.toml
+++ b/ContractExamples/Cargo.toml
@@ -27,9 +27,3 @@ lto = true
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
-
-[profile.release.package.soroban-env-host]
-debug = false
-
-[profile.release.package.stellar-xdr]
-debug = false

--- a/ContractExamples/Cargo.toml
+++ b/ContractExamples/Cargo.toml
@@ -6,6 +6,10 @@ members = [
   "soroban-examples/timelock/"
 ]
 
+[workspace.package]
+version = "22.0.0-rc.3"
+edition = "2021"
+
 [workspace.dependencies]
 soroban-sdk = "22.0.0-rc.3"
 
@@ -23,3 +27,9 @@ lto = true
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
+
+[profile.release.package.soroban-env-host]
+debug = false
+
+[profile.release.package.stellar-xdr]
+debug = false

--- a/ContractExamples/Cargo.toml
+++ b/ContractExamples/Cargo.toml
@@ -10,8 +10,9 @@ members = [
 version = "22.0.0-rc.3"
 edition = "2021"
 
-[workspace.dependencies]
-soroban-sdk = "22.0.0-rc.3"
+[dependencies]
+soroban-sdk = { version = "22.0.0-rc.3.1" }
+soroban-token-sdk = { version = "22.0.0-rc.3.1" }
 
 [profile.release]
 opt-level = "z"

--- a/ContractExamples/Cargo.toml
+++ b/ContractExamples/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 version = "22.0.0-rc.3"
 edition = "2021"
 
-[dependencies]
+[workspace.dependencies]
 soroban-sdk = { version = "22.0.0-rc.3.1" }
 soroban-token-sdk = { version = "22.0.0-rc.3.1" }
 

--- a/ContractExamples/contracts/alert/Cargo.toml
+++ b/ContractExamples/contracts/alert/Cargo.toml
@@ -12,4 +12,4 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "22.0.0-rc.3.1", features = ["testutils"] }

--- a/ContractExamples/contracts/megacontract/Cargo.toml
+++ b/ContractExamples/contracts/megacontract/Cargo.toml
@@ -12,4 +12,4 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "22.0.0-rc.3.1", features = ["testutils"] }

--- a/ContractExamples/contracts/setter/Cargo.toml
+++ b/ContractExamples/contracts/setter/Cargo.toml
@@ -12,4 +12,4 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "22.0.0-rc.3.1", features = ["testutils"] }

--- a/ContractExamples/patches/xycloans.diff
+++ b/ContractExamples/patches/xycloans.diff
@@ -1,7 +1,21 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index e3a7104..bcca0fe 100644
+index e3a7104..b18672f 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
+@@ -3,11 +3,11 @@ resolver = "2"
+ members = [
+     #"flash-loan",
+     #"receiver-standard",
++    "pool",
++    "factory",
+     "examples/simple",
+     #"vault",
+     #"vault-interface",
+-    "factory",
+-    "pool"
+ ]
+ 
+ [profile.release-with-logs]
 @@ -26,8 +26,8 @@ lto = true
  
  

--- a/ContractExamples/patches/xycloans.diff
+++ b/ContractExamples/patches/xycloans.diff
@@ -1,0 +1,16 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index e3a7104..bcca0fe 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -26,8 +26,8 @@ lto = true
+ 
+ 
+ [workspace.dependencies.soroban-sdk]
+-version = "20.0.0"
++version = "22.0.0-rc.3"
+ 
+ 
+ [workspace.dependencies.fixed-point-math]
+-version = "0.0.2"
+\ No newline at end of file
++version = "0.0.2"

--- a/ContractExamples/patches/xycloans2.diff
+++ b/ContractExamples/patches/xycloans2.diff
@@ -1,0 +1,13 @@
+diff --git a/examples/simple/src/lib.rs b/examples/simple/src/lib.rs
+index 021a924..c75abb1 100644
+--- a/examples/simple/src/lib.rs
++++ b/examples/simple/src/lib.rs
+@@ -48,7 +48,7 @@ impl FlashLoanReceiver for FlashLoanReceiverContract {
+             .get::<DataKey, i128>(&DataKey::Amount)
+             .unwrap();
+ 
+-        let total_amount = borrowed + compute_fee(&borrowed);
++        let total_amount = borrowed + compute_fee(&borrowed) + 1;
+ 
+         let flash_loan = e
+             .storage()

--- a/ContractExamples/scripts/alert-deploy.sh
+++ b/ContractExamples/scripts/alert-deploy.sh
@@ -23,6 +23,6 @@ stellar keys address $ACCOUNT || (echo "add the account $ACCOUNT via stellar key
 
 set -x
 
-stellar contract build
+./scripts/build.sh
 stellar contract deploy --wasm target/wasm32-unknown-unknown/release/alert.wasm \
       --source $ACCOUNT --network $NET

--- a/ContractExamples/scripts/alert-deploy.sh
+++ b/ContractExamples/scripts/alert-deploy.sh
@@ -11,7 +11,6 @@
 set -e
 
 dir=$(cd `dirname $0`; pwd -P)
-
 cd ${dir}/..
 
 NET=testnet
@@ -24,5 +23,6 @@ stellar keys address $ACCOUNT || (echo "add the account $ACCOUNT via stellar key
 set -x
 
 ./scripts/build.sh
+
 stellar contract deploy --wasm target/wasm32-unknown-unknown/release/alert.wasm \
       --source $ACCOUNT --network $NET

--- a/ContractExamples/scripts/alert-deploy.sh
+++ b/ContractExamples/scripts/alert-deploy.sh
@@ -15,14 +15,14 @@ dir=$(cd `dirname $0`; pwd -P)
 cd ${dir}/..
 
 NET=testnet
-(soroban network ls | grep -q $NET) || (echo "add testnet via soroban network"; exit 1)
+(stellar network ls | grep -q $NET) || (echo "add testnet via stellar network"; exit 1)
 
 ACCOUNT=alice
-soroban keys address $ACCOUNT || (echo "add the account $ACCOUNT via soroban keys generate"; exit 1)
+stellar keys address $ACCOUNT || (echo "add the account $ACCOUNT via stellar keys generate"; exit 1)
 
 
 set -x
 
-soroban contract build
-soroban contract deploy --wasm target/wasm32-unknown-unknown/release/alert.wasm \
+stellar contract build
+stellar contract deploy --wasm target/wasm32-unknown-unknown/release/alert.wasm \
       --source $ACCOUNT --network $NET

--- a/ContractExamples/scripts/build.sh
+++ b/ContractExamples/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # see: https://github.com/stellar/rs-soroban-sdk/pull/1353
-rustc --version | grep 1.81.0 || (echo "Run: rustup default 1.8210"; exit 1)
+rustc --version | grep 1.81.0 || (echo "Run: rustup default 1.81.0"; exit 1)
 
 dir=$(cd `dirname $0`; pwd -P)
 cd ${dir}/..

--- a/ContractExamples/scripts/build.sh
+++ b/ContractExamples/scripts/build.sh
@@ -12,6 +12,7 @@ stellar contract build
 # build xycloans
 cd xycloans
 ./build.sh
+cd ${dir}
 
 # When using rust over 1.82.0:
 #RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release

--- a/ContractExamples/scripts/build.sh
+++ b/ContractExamples/scripts/build.sh
@@ -9,5 +9,12 @@ cd ${dir}/..
 # build our contracts and soroban-examples
 stellar contract build
 
+# build xycloans
+cd ${dir}/../xycloans
+patch --forward -p1 <../patches/xycloans.diff || (echo "patch already applied?")
+patch --forward -p1 <../patches/xycloans2.diff || (echo "patch already applied?")
+
+stellar contract build
+
 # When using rust over 1.81.0:
 #RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release

--- a/ContractExamples/scripts/build.sh
+++ b/ContractExamples/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# NOTE: we should use the standard command, but it does not seem to use the right flags
+# stellar contract build
+
+RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release

--- a/ContractExamples/scripts/build.sh
+++ b/ContractExamples/scripts/build.sh
@@ -11,7 +11,7 @@ stellar contract build
 
 # build xycloans
 cd xycloans
-stellar contract build
+./build.sh
 
 # When using rust over 1.82.0:
 #RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release

--- a/ContractExamples/scripts/build.sh
+++ b/ContractExamples/scripts/build.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 
-# NOTE: we should use the standard command, but it does not seem to use the right flags
-# stellar contract build
+# see: https://github.com/stellar/rs-soroban-sdk/pull/1353
+rustc --version | grep 1.82.0 || (echo "Run: rustup default 1.82.0"; exit 1)
 
-RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release
+dir=$(cd `dirname $0`; pwd -P)
+cd ${dir}/..
+
+# build our contracts and soroban-examples
+stellar contract build
+
+# build xycloans
+cd xycloans
+stellar contract build
+
+# When using rust over 1.82.0:
+#RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release

--- a/ContractExamples/scripts/build.sh
+++ b/ContractExamples/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # see: https://github.com/stellar/rs-soroban-sdk/pull/1353
-rustc --version | grep 1.82.0 || (echo "Run: rustup default 1.82.0"; exit 1)
+rustc --version | grep 1.81.0 || (echo "Run: rustup default 1.8210"; exit 1)
 
 dir=$(cd `dirname $0`; pwd -P)
 cd ${dir}/..
@@ -9,10 +9,5 @@ cd ${dir}/..
 # build our contracts and soroban-examples
 stellar contract build
 
-# build xycloans
-cd xycloans
-./build.sh
-cd ${dir}
-
-# When using rust over 1.82.0:
+# When using rust over 1.81.0:
 #RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release

--- a/ContractExamples/scripts/build.sh
+++ b/ContractExamples/scripts/build.sh
@@ -16,5 +16,7 @@ patch --forward -p1 <../patches/xycloans2.diff || (echo "patch already applied?"
 
 stellar contract build
 
+cd ${dir}
+
 # When using rust over 1.81.0:
 #RUSTFLAGS="-C target-feature=-reference-types" cargo build --target wasm32-unknown-unknown --release

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -12,22 +12,22 @@ set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 ALICE=alice
-soroban keys address $ALICE || (echo "add the account $ALICE via soroban keys generate"; exit 1)
+stellar keys address $ALICE || (echo "add the account $ALICE via stellar keys generate"; exit 1)
 BOB=bob
-soroban keys address $BOB || (echo "add the account $BOB via soroban keys generate"; exit 1)
+stellar keys address $BOB || (echo "add the account $BOB via stellar keys generate"; exit 1)
 
 set -x
 
 TOKEN=$(
-    soroban contract deploy \
+    stellar contract deploy \
     --source-account alice \
     --network testnet \
-    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm
+    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/stellar_token_contract.wasm
 )
 
 echo "Token contract ID: $TOKEN"
 
-soroban contract invoke \
+stellar contract invoke \
     --id $TOKEN \
     --source alice \
     --network testnet \
@@ -38,7 +38,7 @@ soroban contract invoke \
     --name '"TOK"' \
     --symbol '"TOK"'
 
-soroban contract invoke \
+stellar contract invoke \
     --id $TOKEN \
     --source alice \
     --network testnet \
@@ -47,14 +47,14 @@ soroban contract invoke \
     --to alice \
     --amount 100
 
-TIMELOCK=$(soroban contract deploy \
-    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_timelock_contract.wasm \
+TIMELOCK=$(stellar contract deploy \
+    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/stellar_timelock_contract.wasm \
     --source alice \
     --network testnet)
 
 echo "Timelock contract ID: $TIMELOCK"
 
-soroban contract invoke \
+stellar contract invoke \
     --id $TIMELOCK \
     --source alice \
     --network testnet \
@@ -63,10 +63,10 @@ soroban contract invoke \
     --from alice \
     --token $TOKEN \
     --amount 1 \
-    --claimants "[\"$(soroban keys address bob)\"]"\
+    --claimants "[\"$(stellar keys address bob)\"]"\
     --time_bound '{"kind": "After", "timestamp": 0}'
 
-soroban contract invoke \
+stellar contract invoke \
     --id $TIMELOCK \
     --source bob \
     --network testnet \

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -19,6 +19,7 @@ stellar keys address $BOB || (echo "add the account $BOB via stellar keys genera
 set -x
 
 stellar contract deploy \
+    --salt `date +%s`
     --source-account alice \
     --network testnet \
     --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm \
@@ -33,6 +34,7 @@ fi
 echo "Token contract ID: $TOKEN"
 
 stellar contract invoke \
+    --salt date +%s
     --id $TOKEN \
     --source alice \
     --network testnet \

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -22,7 +22,7 @@ TOKEN=$(
     stellar contract deploy \
     --source-account alice \
     --network testnet \
-    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/stellar_token_contract.wasm
+    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm
 )
 
 echo "Token contract ID: $TOKEN"
@@ -48,7 +48,7 @@ stellar contract invoke \
     --amount 100
 
 TIMELOCK=$(stellar contract deploy \
-    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/stellar_timelock_contract.wasm \
+    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_timelock_contract.wasm \
     --source alice \
     --network testnet)
 

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -9,7 +9,8 @@
 
 set -e
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+dir=$(cd `dirname $0`; pwd -P)
+cd ${dir}/..
 
 ALICE=alice
 stellar keys address $ALICE || (echo "add the account $ALICE via stellar keys generate"; exit 1)
@@ -18,11 +19,13 @@ stellar keys address $BOB || (echo "add the account $BOB via stellar keys genera
 
 #set -x
 
+./scripts/build.sh
+
 stellar contract deploy \
     --salt `date +%s` \
     --source-account alice \
     --network testnet \
-    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm \
+    --wasm ./target/wasm32-unknown-unknown/release/soroban_token_contract.wasm \
     -- --admin alice --decimal 18 --name TOK --symbol TOK \
     | tee >.token.id
 
@@ -44,7 +47,7 @@ stellar contract invoke \
     --amount 100
 
 stellar contract deploy \
-    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_timelock_contract.wasm \
+    --wasm ./target/wasm32-unknown-unknown/release/soroban_timelock_contract.wasm \
     --source alice \
     --network testnet \
     | tee >.timelock.id

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -16,7 +16,7 @@ stellar keys address $ALICE || (echo "add the account $ALICE via stellar keys ge
 BOB=bob
 stellar keys address $BOB || (echo "add the account $BOB via stellar keys generate"; exit 1)
 
-set -x
+#set -x
 
 stellar contract deploy \
     --salt `date +%s` \

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -23,6 +23,7 @@ stellar contract deploy \
     --source-account alice \
     --network testnet \
     --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm \
+    -- --admin alice --decimal 18 --name TOK --symbol TOK \
     | tee >.token.id
 
 TOKEN=$(cat .token.id)
@@ -32,18 +33,6 @@ if [ -z "$TOKEN" ]; then
 fi
 
 echo "Token contract ID: $TOKEN"
-
-stellar contract invoke \
-    --salt date +%s \
-    --id $TOKEN \
-    --source alice \
-    --network testnet \
-    -- \
-    initialize \
-    --admin alice \
-    --decimal 18 \
-    --name '"TOK"' \
-    --symbol '"TOK"'
 
 stellar contract invoke \
     --id $TOKEN \

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -18,12 +18,17 @@ stellar keys address $BOB || (echo "add the account $BOB via stellar keys genera
 
 set -x
 
-TOKEN=$(
-    stellar contract deploy \
+stellar contract deploy \
     --source-account alice \
     --network testnet \
-    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm
-)
+    --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm \
+    | tee >.token.id
+
+TOKEN=$(cat .token.id)
+if [ -z "$TOKEN" ]; then
+    echo "Failed to deploy the token contract"
+    exit 1
+fi
 
 echo "Token contract ID: $TOKEN"
 
@@ -47,10 +52,18 @@ stellar contract invoke \
     --to alice \
     --amount 100
 
-TIMELOCK=$(stellar contract deploy \
+stellar contract deploy \
     --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_timelock_contract.wasm \
     --source alice \
-    --network testnet)
+    --network testnet \
+    | tee >.timelock.id
+
+TIMELOCK=$(cat .timelock.id)
+
+if [ -z "$TIMELOCK" ]; then
+    echo "Failed to deploy the timelock contract"
+    exit 1
+fi
 
 echo "Timelock contract ID: $TIMELOCK"
 

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -19,7 +19,7 @@ stellar keys address $BOB || (echo "add the account $BOB via stellar keys genera
 set -x
 
 stellar contract deploy \
-    --salt `date +%s`
+    --salt `date +%s` \
     --source-account alice \
     --network testnet \
     --wasm $SCRIPT_DIR/../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm \
@@ -34,7 +34,7 @@ fi
 echo "Token contract ID: $TOKEN"
 
 stellar contract invoke \
-    --salt date +%s
+    --salt date +%s \
     --id $TOKEN \
     --source alice \
     --network testnet \

--- a/ContractExamples/scripts/prepare-timelock.sh
+++ b/ContractExamples/scripts/prepare-timelock.sh
@@ -22,7 +22,6 @@ stellar keys address $BOB || (echo "add the account $BOB via stellar keys genera
 ./scripts/build.sh
 
 stellar contract deploy \
-    --salt `date +%s` \
     --source-account alice \
     --network testnet \
     --wasm ./target/wasm32-unknown-unknown/release/soroban_token_contract.wasm \

--- a/ContractExamples/scripts/setter-populate.sh
+++ b/ContractExamples/scripts/setter-populate.sh
@@ -62,6 +62,7 @@ stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET 
 stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- remove_bool
 
+# NOTE: we do not do that in the CI script
 # we can provoke a failed transaction by submitting 2 transactions in parallel from different accounts
-stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET -- set_bool_if_notset &
-stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT2 --network $NET -- set_bool_if_notset
+#stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET -- set_bool_if_notset &
+#stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT2 --network $NET -- set_bool_if_notset

--- a/ContractExamples/scripts/setter-populate.sh
+++ b/ContractExamples/scripts/setter-populate.sh
@@ -25,7 +25,8 @@ stellar keys address $ACCOUNT2 || (echo "add the account $ACCOUNT2 via stellar k
 
 set -x
 
-stellar contract build
+./scripts/build.sh
+
 stellar contract deploy --wasm target/wasm32-unknown-unknown/release/setter.wasm \
       --source $ACCOUNT --network $NET | tee >.setter.id
 

--- a/ContractExamples/scripts/setter-populate.sh
+++ b/ContractExamples/scripts/setter-populate.sh
@@ -15,53 +15,53 @@ dir=$(cd `dirname $0`; pwd -P)
 cd ${dir}/..
 
 NET=testnet
-(soroban network ls | grep -q $NET) || (echo "add testnet via soroban network"; exit 1)
+(stellar network ls | grep -q $NET) || (echo "add testnet via stellar network"; exit 1)
 
 ACCOUNT=alice
-soroban keys address $ACCOUNT || (echo "add the account $ACCOUNT via soroban keys generate"; exit 1)
+stellar keys address $ACCOUNT || (echo "add the account $ACCOUNT via stellar keys generate"; exit 1)
 
 ACCOUNT2=bob
-soroban keys address $ACCOUNT2 || (echo "add the account $ACCOUNT2 via soroban keys generate"; exit 1)
+stellar keys address $ACCOUNT2 || (echo "add the account $ACCOUNT2 via stellar keys generate"; exit 1)
 
 set -x
 
-soroban contract build
-soroban contract deploy --wasm target/wasm32-unknown-unknown/release/setter.wasm \
+stellar contract build
+stellar contract deploy --wasm target/wasm32-unknown-unknown/release/setter.wasm \
       --source $ACCOUNT --network $NET | tee >.setter.id
 
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_bool --v true
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_u32 --v 42
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_i32 --v '-42'
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_u64 --v 42
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_i64 --v '-42'
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_u128 --v 42
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_i128 --v '-42'
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_sym --v hello
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_bytes --v beef
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_bytes32 --v beef0123456789beef0123456789beef0123456789ab
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_vec --v '[ 1, -2, 3 ]'
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_map --v '{ "2": 3, "4": 5 }'
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_address --v GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_struct --v '{ "a": 1, "b": "-100" }'
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- set_enum --v '{ "B": "-200" }'
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET \
       -- remove_bool
 
 # we can provoke a failed transaction by submitting 2 transactions in parallel from different accounts
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET -- set_bool_if_notset &
-soroban contract invoke --id $(cat .setter.id) --source $ACCOUNT2 --network $NET -- set_bool_if_notset
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT --network $NET -- set_bool_if_notset &
+stellar contract invoke --id $(cat .setter.id) --source $ACCOUNT2 --network $NET -- set_bool_if_notset

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -13,6 +13,8 @@ set -e
 dir=$(cd `dirname $0`; pwd -P)
 
 ${dir}/build.sh
+cd ${dir}/..
+
 NET=testnet
 (stellar network ls | grep -q $NET) || (echo "add testnet via stellar network"; exit 1)
 

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -33,11 +33,11 @@ BORROW_AMOUNT=1000
 
 set -x
 
-stellar contract deploy --wasm target/wasm32-unknown-unknown/release/xycloans_factory.wasm \
+stellar contract deploy --wasm ./xycloans/target/wasm32-unknown-unknown/release/xycloans_factory.wasm \
       --source $ADMIN --network $NET | tee >.xycloans_factory.id
-stellar contract deploy --wasm target/wasm32-unknown-unknown/release/simple.wasm \
+stellar contract deploy --wasm ./xycloans/target/wasm32-unknown-unknown/release/simple.wasm \
       --source $ADMIN --network $NET | tee >.xycloans_simple.id
-stellar contract install --wasm target/wasm32-unknown-unknown/release/xycloans_pool.wasm \
+stellar contract install --wasm ./xycloans/target/wasm32-unknown-unknown/release/xycloans_pool.wasm \
       --source $ADMIN --network $NET | tee >.xycloans_pool.wasmhash
 
 # initialize the factory contract and deploy a pool

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -17,6 +17,7 @@ rustc --version | grep 1.81.0 || (echo "Run: rustup default 1.81.0"; exit 1)
 
 cd ${dir}/../xycloans
 patch --forward -p1 <../patches/xycloans.diff || (echo "patch already applied?")
+patch --forward -p1 <../patches/xycloans2.diff || (echo "patch already applied?")
 
 stellar contract build
 

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -15,57 +15,57 @@ dir=$(cd `dirname $0`; pwd -P)
 cd ${dir}/../xycloans
 
 NET=testnet
-(soroban network ls | grep -q $NET) || (echo "add testnet via soroban network"; exit 1)
+(stellar network ls | grep -q $NET) || (echo "add testnet via stellar network"; exit 1)
 
 ADMIN=admin
-soroban keys address $ADMIN || (echo "add the account $ADMIN via soroban keys generate"; exit 1)
+stellar keys address $ADMIN || (echo "add the account $ADMIN via stellar keys generate"; exit 1)
 
 ALICE=alice
-soroban keys address $ALICE || (echo "add the account $ALICE via soroban keys generate"; exit 1)
+stellar keys address $ALICE || (echo "add the account $ALICE via stellar keys generate"; exit 1)
 
 BOB=bob
-soroban keys address $BOB || (echo "add the account $BOB via soroban keys generate"; exit 1)
+stellar keys address $BOB || (echo "add the account $BOB via stellar keys generate"; exit 1)
 
 XLM_ADDRESS=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
 BORROW_AMOUNT=1000
 
 set -x
 
-soroban contract build
+stellar contract build
 
-soroban contract deploy --wasm target/wasm32-unknown-unknown/release/xycloans_factory.wasm \
+stellar contract deploy --wasm target/wasm32-unknown-unknown/release/xycloans_factory.wasm \
       --source $ADMIN --network $NET | tee >.xycloans_factory.id
-soroban contract deploy --wasm target/wasm32-unknown-unknown/release/simple.wasm \
+stellar contract deploy --wasm target/wasm32-unknown-unknown/release/simple.wasm \
       --source $ADMIN --network $NET | tee >.xycloans_simple.id
-soroban contract install --wasm target/wasm32-unknown-unknown/release/xycloans_pool.wasm \
+stellar contract install --wasm target/wasm32-unknown-unknown/release/xycloans_pool.wasm \
       --source $ADMIN --network $NET | tee >.xycloans_pool.wasmhash
 
 # initialize the factory contract and deploy a pool
-soroban contract invoke --id $(cat .xycloans_factory.id) --source $ADMIN --network $NET \
+stellar contract invoke --id $(cat .xycloans_factory.id) --source $ADMIN --network $NET \
       -- initialize --pool_hash $(cat .xycloans_pool.wasmhash) --admin $ADMIN
-soroban contract invoke --id $(cat .xycloans_factory.id) --source $ADMIN --network $NET \
+stellar contract invoke --id $(cat .xycloans_factory.id) --source $ADMIN --network $NET \
       -- deploy_pool --token_address $XLM_ADDRESS --salt efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef | tr -d '"' | tee >.xycloans_pool.id
 
 # initialize the simple receiver contract and transfer it some tokens so it can pay fees
-soroban contract invoke --id $(cat .xycloans_simple.id) --source $ADMIN --network $NET \
+stellar contract invoke --id $(cat .xycloans_simple.id) --source $ADMIN --network $NET \
       -- init --token_id $XLM_ADDRESS --fl_address $(cat .xycloans_pool.id) --amount $BORROW_AMOUNT
-soroban contract invoke --id $XLM_ADDRESS --source $ADMIN --network $NET \
+stellar contract invoke --id $XLM_ADDRESS --source $ADMIN --network $NET \
       -- transfer --from $ADMIN --to $(cat .xycloans_simple.id) --amount 10000
 
 # deposit some tokens into the pool
-soroban contract invoke --id $(cat .xycloans_pool.id) --source $ALICE --network $NET \
+stellar contract invoke --id $(cat .xycloans_pool.id) --source $ALICE --network $NET \
       -- deposit --from $ALICE --amount 1000
-soroban contract invoke --id $(cat .xycloans_pool.id) --source $BOB --network $NET \
+stellar contract invoke --id $(cat .xycloans_pool.id) --source $BOB --network $NET \
       -- deposit --from $BOB --amount 1
 
 # borrow some tokens from the pool
-soroban contract invoke --id $(cat .xycloans_pool.id) --source $ADMIN --network $NET \
+stellar contract invoke --id $(cat .xycloans_pool.id) --source $ADMIN --network $NET \
       -- borrow --receiver_id $(cat .xycloans_simple.id) --amount $BORROW_AMOUNT
 
 # update the fee rewards and withdraw the matured rewards
-soroban contract invoke --id $(cat .xycloans_pool.id) --source $BOB --network $NET \
+stellar contract invoke --id $(cat .xycloans_pool.id) --source $BOB --network $NET \
       -- update_fee_rewards --addr $BOB
-soroban contract invoke --id $(cat .xycloans_pool.id) --source $BOB --network $NET \
+stellar contract invoke --id $(cat .xycloans_pool.id) --source $BOB --network $NET \
       -- withdraw_matured --addr $BOB
 
 cd ${dir}

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -12,15 +12,7 @@ set -e
 
 dir=$(cd `dirname $0`; pwd -P)
 
-# see: https://github.com/stellar/rs-soroban-sdk/pull/1353
-rustc --version | grep 1.81.0 || (echo "Run: rustup default 1.81.0"; exit 1)
-
-cd ${dir}/../xycloans
-patch --forward -p1 <../patches/xycloans.diff || (echo "patch already applied?")
-patch --forward -p1 <../patches/xycloans2.diff || (echo "patch already applied?")
-
-stellar contract build
-
+${dir}/build.sh
 NET=testnet
 (stellar network ls | grep -q $NET) || (echo "add testnet via stellar network"; exit 1)
 

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -26,6 +26,7 @@ stellar keys address $ALICE || (echo "add the account $ALICE via stellar keys ge
 BOB=bob
 stellar keys address $BOB || (echo "add the account $BOB via stellar keys generate"; exit 1)
 
+# XLM SAC token address: https://developers.stellar.org/docs/tokens/stellar-asset-contract
 XLM_ADDRESS=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
 BORROW_AMOUNT=1000
 

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -12,7 +12,15 @@ set -e
 
 dir=$(cd `dirname $0`; pwd -P)
 
+# see: https://github.com/stellar/rs-soroban-sdk/pull/1353
+rustc --version | grep 1.82.0 || (echo "Run: rustup default 1.82.0"; exit 1)
+
 cd ${dir}/../xycloans
+patch --forward -p1 <../patches/xycloans.diff || (echo "patch already applied?")
+
+stellar contract build --package xycloans-pool
+stellar contract build --package xycloans-factory
+stellar contract build --package simple
 
 NET=testnet
 (stellar network ls | grep -q $NET) || (echo "add testnet via stellar network"; exit 1)
@@ -31,8 +39,6 @@ XLM_ADDRESS=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
 BORROW_AMOUNT=1000
 
 set -x
-
-../scripts/build.sh
 
 stellar contract deploy --wasm target/wasm32-unknown-unknown/release/xycloans_factory.wasm \
       --source $ADMIN --network $NET | tee >.xycloans_factory.id

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -31,7 +31,7 @@ BORROW_AMOUNT=1000
 
 set -x
 
-stellar contract build
+../scripts/build.sh
 
 stellar contract deploy --wasm target/wasm32-unknown-unknown/release/xycloans_factory.wasm \
       --source $ADMIN --network $NET | tee >.xycloans_factory.id

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -18,9 +18,7 @@ rustc --version | grep 1.82.0 || (echo "Run: rustup default 1.82.0"; exit 1)
 cd ${dir}/../xycloans
 patch --forward -p1 <../patches/xycloans.diff || (echo "patch already applied?")
 
-stellar contract build --package xycloans-pool
-stellar contract build --package xycloans-factory
-stellar contract build --package simple
+stellar contract build
 
 NET=testnet
 (stellar network ls | grep -q $NET) || (echo "add testnet via stellar network"; exit 1)

--- a/ContractExamples/scripts/xycloans-populate.sh
+++ b/ContractExamples/scripts/xycloans-populate.sh
@@ -13,7 +13,7 @@ set -e
 dir=$(cd `dirname $0`; pwd -P)
 
 # see: https://github.com/stellar/rs-soroban-sdk/pull/1353
-rustc --version | grep 1.82.0 || (echo "Run: rustup default 1.82.0"; exit 1)
+rustc --version | grep 1.81.0 || (echo "Run: rustup default 1.81.0"; exit 1)
 
 cd ${dir}/../xycloans
 patch --forward -p1 <../patches/xycloans.diff || (echo "patch already applied?")

--- a/solarkraft/package-lock.json
+++ b/solarkraft/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^11.0.1",
-        "@stellar/stellar-sdk": "^12.2.0",
+        "@stellar/stellar-base": "^12.1.1",
+        "@stellar/stellar-sdk": "^13.0",
         "@sweet-monads/either": "^3.3.1",
         "@sweet-monads/maybe": "^3.3.1",
         "@types/urijs": "^1.19.25",
@@ -29,7 +29,7 @@
         "solarkraft": "dist/src/main.js"
       },
       "devDependencies": {
-        "@eslint/js": "^9.0.0",
+        "@eslint/js": "^9.16.0",
         "@types/eventsource": "^1.1.15",
         "@types/lodash": "^4.17.9",
         "@types/node": "^20.11.26",
@@ -44,7 +44,7 @@
         "prettier": "^3.2.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5",
-        "typescript-eslint": "^7.6.0"
+        "typescript-eslint": "^8.17.0"
       },
       "engines": {
         "node": ">=18"
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.0.0.tgz",
-      "integrity": "sha512-RThY/MnKrhubF6+s1JflwUjPEsnCEmYCWwqa/aRISKWNXGZ9epUwft4bUMM35SdKF9xvBrLydAM1RDHd1Z//ZQ==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
+      "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -321,12 +321,11 @@
       "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-11.1.0.tgz",
-      "integrity": "sha512-nMg7QSpFqCZFq3Je/lG12+DY18y01QHRNyCxvjM8i4myS9tPRMDq7zqGcd215BGbCJxenckiOW45YJjQjzdcMQ==",
-      "deprecated": "⚠️ This version contains breaking changes, use v11.0.1 for compatibility or upgrade to v12.",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
+      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
       "dependencies": {
-        "@stellar/js-xdr": "^3.1.1",
+        "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
         "bignumber.js": "^9.1.2",
         "buffer": "^6.0.3",
@@ -338,23 +337,24 @@
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.2.0.tgz",
-      "integrity": "sha512-Wy5sDOqb5JvAC76f4sQIV6Pe3JNyZb0PuyVNjwt3/uWsjtxRkFk6s2yTHTefBLWoR+mKxDjO7QfzhycF1v8FXQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.0.0.tgz",
+      "integrity": "sha512-+wvmKi+XWwu27nLYTM17EgBdpbKohEkOfCIK4XKfsI4WpMXAqvnqSm98i9h5dAblNB+w8BJqzGs1JY0PtTGm4A==",
       "dependencies": {
-        "@stellar/stellar-base": "^12.1.0",
-        "axios": "^1.7.2",
+        "@stellar/stellar-base": "^13.0.1",
+        "axios": "^1.7.7",
         "bignumber.js": "^9.1.2",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.20",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
       }
     },
     "node_modules/@stellar/stellar-sdk/node_modules/@stellar/stellar-base": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.0.tgz",
-      "integrity": "sha512-pWwn+XWP5NotmIteZNuJzHeNn9DYSqH3lsYbtFUoSYy1QegzZdi9D8dK6fJ2fpBAnf/rcDjHgHOw3gtHaQFVbg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.0.1.tgz",
+      "integrity": "sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==",
       "dependencies": {
         "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
@@ -364,7 +364,7 @@
         "tweetnacl": "^1.0.3"
       },
       "optionalDependencies": {
-        "sodium-native": "^4.1.1"
+        "sodium-native": "^4.3.0"
       }
     },
     "node_modules/@sweet-monads/either": {
@@ -427,12 +427,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
     "node_modules/@types/lodash": {
       "version": "4.17.9",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.9.tgz",
@@ -453,45 +447,37 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
-    },
     "node_modules/@types/urijs": {
       "version": "1.19.25",
       "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.25.tgz",
       "integrity": "sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.6.0.tgz",
-      "integrity": "sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.17.0.tgz",
+      "integrity": "sha512-HU1KAdW3Tt8zQkdvNoIijfWDMvdSweFYm4hWh+KwhPstv+sCmWb89hCIP8msFm9N1R/ooh9honpSuvqKWlYy3w==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/type-utils": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
-        "debug": "^4.3.4",
+        "@typescript-eslint/scope-manager": "8.17.0",
+        "@typescript-eslint/type-utils": "8.17.0",
+        "@typescript-eslint/utils": "8.17.0",
+        "@typescript-eslint/visitor-keys": "8.17.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.6.0",
         "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.56.0"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -500,26 +486,26 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.6.0.tgz",
-      "integrity": "sha512-usPMPHcwX3ZoPWnBnhhorc14NJw9J4HpSXQX4urF2TPKG0au0XhJoZyX62fmvdHONUkmyUe74Hzm1//XA+BoYg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.17.0.tgz",
+      "integrity": "sha512-Drp39TXuUlD49F7ilHHCG7TTg8IkA+hxCuULdmzWYICxGXvDXmDmWEjJYZQYgf6l/TFfYNE167m7isnc3xlIEg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/scope-manager": "8.17.0",
+        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/typescript-estree": "8.17.0",
+        "@typescript-eslint/visitor-keys": "8.17.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -528,16 +514,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.6.0.tgz",
-      "integrity": "sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.17.0.tgz",
+      "integrity": "sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0"
+        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/visitor-keys": "8.17.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -545,25 +531,25 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.6.0.tgz",
-      "integrity": "sha512-NxAfqAPNLG6LTmy7uZgpK8KcuiS2NZD/HlThPXQRGwz6u7MDBWRVliEEl1Gj6U7++kVJTpehkhZzCJLMK66Scw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.17.0.tgz",
+      "integrity": "sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0",
+        "@typescript-eslint/typescript-estree": "8.17.0",
+        "@typescript-eslint/utils": "8.17.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -572,12 +558,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.6.0.tgz",
-      "integrity": "sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.17.0.tgz",
+      "integrity": "sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==",
       "dev": true,
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -585,22 +571,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.6.0.tgz",
-      "integrity": "sha512-+7Y/GP9VuYibecrCQWSKgl3GvUM5cILRttpWtnAu8GNL9j11e4tbuGZmZjJ8ejnKYyBRb2ddGQ3rEFCq3QjMJw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.17.0.tgz",
+      "integrity": "sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/visitor-keys": "8.17.0",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
         "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -621,30 +607,10 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -657,45 +623,59 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.6.0.tgz",
-      "integrity": "sha512-x54gaSsRRI+Nwz59TXpCsr6harB98qjXYzsRxGqvA5Ue3kQH+FxS7FYU81g/omn22ML2pZJkisy6Q+ElK8pBCA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.17.0.tgz",
+      "integrity": "sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.15",
-        "@types/semver": "^7.5.8",
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "semver": "^7.6.0"
+        "@typescript-eslint/scope-manager": "8.17.0",
+        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/typescript-estree": "8.17.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.6.0.tgz",
-      "integrity": "sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.17.0.tgz",
+      "integrity": "sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
-        "eslint-visitor-keys": "^3.4.3"
+        "@typescript-eslint/types": "8.17.0",
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -833,9 +813,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1601,6 +1581,14 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.20.tgz",
+      "integrity": "sha512-g3hm2YDNffNxA3Re3Hd8ahbpmDee9Fv1Pb1C/NoWsjY7mtD8nyNeJytUzn+DK0Hyl9o6HppeWOrtnqgmhOYfWA==",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2104,6 +2092,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -2338,18 +2337,6 @@
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -3070,13 +3057,10 @@
       "integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg=="
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3144,10 +3128,9 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.1.1.tgz",
-      "integrity": "sha512-LXkAfRd4FHtkQS4X6g+nRcVaN7mWVNepV06phIsC6+IZFvGh1voW5TNQiQp2twVaMf05gZqQjuS+uWLM6gHhNQ==",
-      "hasInstallScript": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+      "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.8.0"
@@ -3405,9 +3388,9 @@
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "node_modules/ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -3511,24 +3494,24 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.6.0.tgz",
-      "integrity": "sha512-LY6vH6F1l5jpGqRtU+uK4+mOecIb4Cd4kaz1hAiJrgnNiHUA8wiw8BkJyYS+MRLM69F1QuSKwtGlQqnGl1Rc6w==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.17.0.tgz",
+      "integrity": "sha512-409VXvFd/f1br1DCbuKNFqQpXICoTB+V51afcwG1pn1a3Cp92MqAUges3YjwEdQ0cMUoCIodjVDAYzyD8h3SYA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "7.6.0",
-        "@typescript-eslint/parser": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0"
+        "@typescript-eslint/eslint-plugin": "8.17.0",
+        "@typescript-eslint/parser": "8.17.0",
+        "@typescript-eslint/utils": "8.17.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3665,12 +3648,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -3790,9 +3767,9 @@
       }
     },
     "@eslint/js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.0.0.tgz",
-      "integrity": "sha512-RThY/MnKrhubF6+s1JflwUjPEsnCEmYCWwqa/aRISKWNXGZ9epUwft4bUMM35SdKF9xvBrLydAM1RDHd1Z//ZQ==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
+      "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -3933,11 +3910,11 @@
       "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
     },
     "@stellar/stellar-base": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-11.1.0.tgz",
-      "integrity": "sha512-nMg7QSpFqCZFq3Je/lG12+DY18y01QHRNyCxvjM8i4myS9tPRMDq7zqGcd215BGbCJxenckiOW45YJjQjzdcMQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
+      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
       "requires": {
-        "@stellar/js-xdr": "^3.1.1",
+        "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
         "bignumber.js": "^9.1.2",
         "buffer": "^6.0.3",
@@ -3947,30 +3924,31 @@
       }
     },
     "@stellar/stellar-sdk": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.2.0.tgz",
-      "integrity": "sha512-Wy5sDOqb5JvAC76f4sQIV6Pe3JNyZb0PuyVNjwt3/uWsjtxRkFk6s2yTHTefBLWoR+mKxDjO7QfzhycF1v8FXQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.0.0.tgz",
+      "integrity": "sha512-+wvmKi+XWwu27nLYTM17EgBdpbKohEkOfCIK4XKfsI4WpMXAqvnqSm98i9h5dAblNB+w8BJqzGs1JY0PtTGm4A==",
       "requires": {
-        "@stellar/stellar-base": "^12.1.0",
-        "axios": "^1.7.2",
+        "@stellar/stellar-base": "^13.0.1",
+        "axios": "^1.7.7",
         "bignumber.js": "^9.1.2",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.20",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
       },
       "dependencies": {
         "@stellar/stellar-base": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.0.tgz",
-          "integrity": "sha512-pWwn+XWP5NotmIteZNuJzHeNn9DYSqH3lsYbtFUoSYy1QegzZdi9D8dK6fJ2fpBAnf/rcDjHgHOw3gtHaQFVbg==",
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.0.1.tgz",
+          "integrity": "sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==",
           "requires": {
             "@stellar/js-xdr": "^3.1.2",
             "base32.js": "^0.1.0",
             "bignumber.js": "^9.1.2",
             "buffer": "^6.0.3",
             "sha.js": "^2.3.6",
-            "sodium-native": "^4.1.1",
+            "sodium-native": "^4.3.0",
             "tweetnacl": "^1.0.3"
           }
         }
@@ -4036,12 +4014,6 @@
         "@types/node": "*"
       }
     },
-    "@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
     "@types/lodash": {
       "version": "4.17.9",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.9.tgz",
@@ -4061,87 +4033,79 @@
         "undici-types": "~5.26.4"
       }
     },
-    "@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
-    },
     "@types/urijs": {
       "version": "1.19.25",
       "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.25.tgz",
       "integrity": "sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.6.0.tgz",
-      "integrity": "sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.17.0.tgz",
+      "integrity": "sha512-HU1KAdW3Tt8zQkdvNoIijfWDMvdSweFYm4hWh+KwhPstv+sCmWb89hCIP8msFm9N1R/ooh9honpSuvqKWlYy3w==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/type-utils": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
-        "debug": "^4.3.4",
+        "@typescript-eslint/scope-manager": "8.17.0",
+        "@typescript-eslint/type-utils": "8.17.0",
+        "@typescript-eslint/utils": "8.17.0",
+        "@typescript-eslint/visitor-keys": "8.17.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.6.0",
         "ts-api-utils": "^1.3.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.6.0.tgz",
-      "integrity": "sha512-usPMPHcwX3ZoPWnBnhhorc14NJw9J4HpSXQX4urF2TPKG0au0XhJoZyX62fmvdHONUkmyUe74Hzm1//XA+BoYg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.17.0.tgz",
+      "integrity": "sha512-Drp39TXuUlD49F7ilHHCG7TTg8IkA+hxCuULdmzWYICxGXvDXmDmWEjJYZQYgf6l/TFfYNE167m7isnc3xlIEg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/scope-manager": "8.17.0",
+        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/typescript-estree": "8.17.0",
+        "@typescript-eslint/visitor-keys": "8.17.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.6.0.tgz",
-      "integrity": "sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.17.0.tgz",
+      "integrity": "sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0"
+        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/visitor-keys": "8.17.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.6.0.tgz",
-      "integrity": "sha512-NxAfqAPNLG6LTmy7uZgpK8KcuiS2NZD/HlThPXQRGwz6u7MDBWRVliEEl1Gj6U7++kVJTpehkhZzCJLMK66Scw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.17.0.tgz",
+      "integrity": "sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0",
+        "@typescript-eslint/typescript-estree": "8.17.0",
+        "@typescript-eslint/utils": "8.17.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.6.0.tgz",
-      "integrity": "sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.17.0.tgz",
+      "integrity": "sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.6.0.tgz",
-      "integrity": "sha512-+7Y/GP9VuYibecrCQWSKgl3GvUM5cILRttpWtnAu8GNL9j11e4tbuGZmZjJ8ejnKYyBRb2ddGQ3rEFCq3QjMJw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.17.0.tgz",
+      "integrity": "sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/visitor-keys": "8.17.0",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
@@ -4157,24 +4121,10 @@
             "balanced-match": "^1.0.0"
           }
         },
-        "globby": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.2.9",
-            "ignore": "^5.2.0",
-            "merge2": "^1.4.1",
-            "slash": "^3.0.0"
-          }
-        },
         "minimatch": {
-          "version": "9.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -4183,28 +4133,33 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.6.0.tgz",
-      "integrity": "sha512-x54gaSsRRI+Nwz59TXpCsr6harB98qjXYzsRxGqvA5Ue3kQH+FxS7FYU81g/omn22ML2pZJkisy6Q+ElK8pBCA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.17.0.tgz",
+      "integrity": "sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.15",
-        "@types/semver": "^7.5.8",
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "semver": "^7.6.0"
+        "@typescript-eslint/scope-manager": "8.17.0",
+        "@typescript-eslint/types": "8.17.0",
+        "@typescript-eslint/typescript-estree": "8.17.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.6.0.tgz",
-      "integrity": "sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.17.0.tgz",
+      "integrity": "sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.6.0",
-        "eslint-visitor-keys": "^3.4.3"
+        "@typescript-eslint/types": "8.17.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+          "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+          "dev": true
+        }
       }
     },
     "@ungap/structured-clone": {
@@ -4306,9 +4261,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4855,6 +4810,14 @@
         "reusify": "^1.0.4"
       }
     },
+    "feaxios": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.20.tgz",
+      "integrity": "sha512-g3hm2YDNffNxA3Re3Hd8ahbpmDee9Fv1Pb1C/NoWsjY7mtD8nyNeJytUzn+DK0Hyl9o6HppeWOrtnqgmhOYfWA==",
+      "requires": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5200,6 +5163,11 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
+    "is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A=="
+    },
     "is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -5375,15 +5343,6 @@
       "dev": true,
       "requires": {
         "get-func-name": "^2.0.1"
-      }
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
       }
     },
     "make-error": {
@@ -5903,13 +5862,10 @@
       "integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg=="
     },
     "semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -5953,9 +5909,9 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "sodium-native": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.1.1.tgz",
-      "integrity": "sha512-LXkAfRd4FHtkQS4X6g+nRcVaN7mWVNepV06phIsC6+IZFvGh1voW5TNQiQp2twVaMf05gZqQjuS+uWLM6gHhNQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+      "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
       "optional": true,
       "requires": {
         "node-gyp-build": "^4.8.0"
@@ -6160,9 +6116,9 @@
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
       "dev": true,
       "requires": {}
     },
@@ -6222,14 +6178,14 @@
       "dev": true
     },
     "typescript-eslint": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.6.0.tgz",
-      "integrity": "sha512-LY6vH6F1l5jpGqRtU+uK4+mOecIb4Cd4kaz1hAiJrgnNiHUA8wiw8BkJyYS+MRLM69F1QuSKwtGlQqnGl1Rc6w==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.17.0.tgz",
+      "integrity": "sha512-409VXvFd/f1br1DCbuKNFqQpXICoTB+V51afcwG1pn1a3Cp92MqAUges3YjwEdQ0cMUoCIodjVDAYzyD8h3SYA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/eslint-plugin": "7.6.0",
-        "@typescript-eslint/parser": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0"
+        "@typescript-eslint/eslint-plugin": "8.17.0",
+        "@typescript-eslint/parser": "8.17.0",
+        "@typescript-eslint/utils": "8.17.0"
       }
     },
     "undici-types": {
@@ -6326,12 +6282,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "yargs": {
       "version": "17.7.2",

--- a/solarkraft/package.json
+++ b/solarkraft/package.json
@@ -41,8 +41,8 @@
     "test": "mocha --loader=ts-node/esm --exclude test/e2e/**/*.test.ts --exclude test/integration/**/*.test.ts test/**/*.test.ts"
   },
   "dependencies": {
-    "@stellar/stellar-base": "^11.0.1",
-    "@stellar/stellar-sdk": "^12.2.0",
+    "@stellar/stellar-base": "^12.1.1",
+    "@stellar/stellar-sdk": "^13.0",
     "@sweet-monads/either": "^3.3.1",
     "@sweet-monads/maybe": "^3.3.1",
     "@types/urijs": "^1.19.25",
@@ -58,7 +58,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.0.0",
+    "@eslint/js": "^9.16.0",
     "@types/eventsource": "^1.1.15",
     "@types/lodash": "^4.17.9",
     "@types/node": "^20.11.26",
@@ -73,7 +73,7 @@
     "prettier": "^3.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
-    "typescript-eslint": "^7.6.0"
+    "typescript-eslint": "^8.17.0"
   },
   "engines": {
     "node": ">=18"

--- a/solarkraft/package.json
+++ b/solarkraft/package.json
@@ -41,7 +41,6 @@
     "test": "mocha --loader=ts-node/esm --exclude test/e2e/**/*.test.ts --exclude test/integration/**/*.test.ts test/**/*.test.ts"
   },
   "dependencies": {
-    "@stellar/stellar-base": "^12.1.1",
     "@stellar/stellar-sdk": "^13.0",
     "@sweet-monads/either": "^3.3.1",
     "@sweet-monads/maybe": "^3.3.1",

--- a/solarkraft/src/fetch.ts
+++ b/solarkraft/src/fetch.ts
@@ -42,7 +42,7 @@
  * those values are indistinguishable from vectors at the transaction data layer.
  */
 
-import { Horizon } from '@stellar/stellar-sdk'
+import { Horizon, rpc } from '@stellar/stellar-sdk'
 import { extractContractCall } from './fetcher/callDecoder.js'
 import {
     loadFetcherState,
@@ -67,7 +67,10 @@ export async function fetch(args: any) {
         return
     }
 
-    const server = new Horizon.Server(args.rpc)
+    // previously, we used the Horizon API
+    const server = new Horizon.Server(args.horizon)
+    // but now we also need the Soroban RPC to extract detailed transactions
+    const rpcServer = new rpc.Server(args.rpc)
 
     const contractId = args.id
     console.log(`Target contract: ${contractId}...`)
@@ -122,6 +125,7 @@ export async function fetch(args: any) {
                 }
                 op = op as Horizon.ServerApi.InvokeHostFunctionOperationRecord
                 const callEntryMaybe = await extractContractCall(
+                    rpcServer,
                     op,
                     (id) => contractId === id,
                     typemapJson

--- a/solarkraft/src/fetcher/callDecoder.ts
+++ b/solarkraft/src/fetcher/callDecoder.ts
@@ -85,6 +85,9 @@ export async function extractContractCall(
     const txDetails = await rpcServer.getTransaction(txHash)
     if (txDetails.status == rpc.Api.GetTransactionStatus.NOT_FOUND) {
         // this transaction is missing
+        console.log(
+            `Transaction ${txHash} reported by Horizon but not found by Soroban RPC`
+        )
         return none()
     }
 

--- a/solarkraft/src/main.ts
+++ b/solarkraft/src/main.ts
@@ -42,10 +42,15 @@ const fetchCmd = {
                 type: 'string',
                 require: false,
             })
-            .option('rpc', {
+            .option('horizon', {
                 desc: 'URL of a Horizon endpoint',
                 type: 'string',
                 default: 'https://horizon-testnet.stellar.org',
+            })
+            .option('rpc', {
+                desc: 'URL of a Soroban RPC endpoint',
+                type: 'string',
+                default: 'https://soroban-testnet.stellar.org',
             })
             .option('height', {
                 desc: 'The height to start with (a negative value -n goes from the latest block - n)',

--- a/solarkraft/src/verifier/invokeAlert.ts
+++ b/solarkraft/src/verifier/invokeAlert.ts
@@ -1,6 +1,6 @@
 import {
     Contract,
-    SorobanRpc,
+    rpc,
     TransactionBuilder,
     Networks,
     BASE_FEE,
@@ -33,7 +33,7 @@ export async function invokeAlert(
     verificationStatus: VerificationStatus
 ): Promise<VerificationStatus> {
     const alertContract = new Contract(alertContractId)
-    const server = new SorobanRpc.Server(sorobanRpcServer)
+    const server = new rpc.Server(sorobanRpcServer)
 
     // We have to build the method params from the JS ones
     const txHashAsScVal = xdr.ScVal.scvString(txHash)

--- a/solarkraft/src/verify_js.ts
+++ b/solarkraft/src/verify_js.ts
@@ -359,7 +359,7 @@ function logEvaluationError(e: Error) {
                     console.error(' '.repeat(parseInt(pos) - 1) + '^')
                 }
             })
-    } catch (e) {
+    } catch {
         // fail silently
     }
 }

--- a/solarkraft/test/e2e/invokeAlert.test.ts
+++ b/solarkraft/test/e2e/invokeAlert.test.ts
@@ -24,7 +24,7 @@ describe('alert contract invocation', () => {
                     sourceKeypair.publicKey()
                 )}`
             )
-        } catch (e) {
+        } catch {
             assert(false)
         }
 

--- a/solarkraft/test/integration/callDecoder.test.ts
+++ b/solarkraft/test/integration/callDecoder.test.ts
@@ -57,10 +57,12 @@ const bytes32 = Buffer.from([
 // extract the only contract entry from a given ledger
 async function extractEntry(txHash: string): Promise<ContractCallEntry> {
     const server = new Horizon.Server(HORIZON_URL)
+    const rpcServer = new rpc.Server(SOROBAN_URL)
     const operations = await server.operations().forTransaction(txHash).call()
     let resultingEntry: Maybe<ContractCallEntry> = none<ContractCallEntry>()
     for (const op of operations.records) {
         const entry = await extractContractCall(
+            rpcServer,
             op as Horizon.ServerApi.InvokeHostFunctionOperationRecord,
             (id) => id === CONTRACT_ID
         )

--- a/solarkraft/test/integration/callDecoder.test.ts
+++ b/solarkraft/test/integration/callDecoder.test.ts
@@ -18,7 +18,7 @@ import {
     nativeToScVal,
     Networks,
     Operation,
-    SorobanRpc,
+    rpc,
     Transaction,
     TransactionBuilder,
     xdr,
@@ -84,15 +84,15 @@ async function extractEntry(txHash: string): Promise<ContractCallEntry> {
 
 // submit a transaction, return its transaction hash and the response
 async function submitTx(
-    server: SorobanRpc.Server,
+    server: rpc.Server,
     tx: Transaction,
     keypair: Keypair
 ): Promise<
     [
         string,
         (
-            | SorobanRpc.Api.GetSuccessfulTransactionResponse
-            | SorobanRpc.Api.GetFailedTransactionResponse
+            | rpc.Api.GetSuccessfulTransactionResponse
+            | rpc.Api.GetFailedTransactionResponse
         ),
     ]
 > {
@@ -128,13 +128,13 @@ async function callContract(
     [
         string,
         (
-            | SorobanRpc.Api.GetSuccessfulTransactionResponse
-            | SorobanRpc.Api.GetFailedTransactionResponse
+            | rpc.Api.GetSuccessfulTransactionResponse
+            | rpc.Api.GetFailedTransactionResponse
         ),
     ]
 > {
     // adapted from https://developers.stellar.org/docs/learn/encyclopedia/contract-development/contract-interactions/stellar-transaction#function
-    const server = new SorobanRpc.Server(SOROBAN_URL)
+    const server = new rpc.Server(SOROBAN_URL)
 
     // the deployed setter contract
     const contract = new Contract(CONTRACT_ID)
@@ -171,7 +171,7 @@ describe('call decoder from Horizon', function () {
 
         // Redeploy a fresh copy of the setter contract WASM from CONTRACT_ID_TEMPLATE
         console.log(`Creating a contract from WASM code ${WASM_HASH} ...`)
-        const soroban = new SorobanRpc.Server(SOROBAN_URL)
+        const soroban = new rpc.Server(SOROBAN_URL)
         const sourceAccount = await soroban.getAccount(alice.publicKey())
         const builtTransaction = new TransactionBuilder(sourceAccount, {
             fee: BASE_FEE,
@@ -1321,7 +1321,7 @@ describe('call decoder from Horizon', function () {
         // submit 2 conflicting tx in parallel by different accounts to provoke a failed transaction
 
         // Craft a conflicting transaction
-        const server = new SorobanRpc.Server(SOROBAN_URL)
+        const server = new rpc.Server(SOROBAN_URL)
         const contract = new Contract(CONTRACT_ID)
         const sourceAccount = await server.getAccount(bob.publicKey())
         const builtTransaction = new TransactionBuilder(sourceAccount, {

--- a/solarkraft/test/integration/callDecoder.test.ts
+++ b/solarkraft/test/integration/callDecoder.test.ts
@@ -35,7 +35,7 @@ const SOROBAN_URL = 'https://soroban-testnet.stellar.org:443'
 
 // hard-coded WASM code hash of the setter contract on the ledger (deployed via setter-populate.sh)
 const WASM_HASH =
-    '61da69e298a4c923eb699c22f4846cfb5f4926ab2b6a572bb85729e108a968d4'
+    'c531f315ccc0f4d3f3d393e8b0e54a4911f3a434c3d06cd2cd895d6e3fa291c3'
 
 // contract ID of the deployed setter contract (will be set up by `before()`)
 let CONTRACT_ID: string


### PR DESCRIPTION
I did not expect that it will take me so much time (like a week) to fix the CI with all the recent Soroban changes. What we have here:
 - [x] An update to stellar/rs-soroban-sdk 22.0.0-rc.3.1 in the examples
 - [x] An update to `@stellar/stellar-sdk` v13.0
 - [x] A downgrade to `rustc` 1.81.0, otherwise, a few examples break on deployment with references-something-we-love-rust, see stellar/rs-soroban-env#1469. 
 - [x] The deployment scripts fixed and working with v22.0.0 on the testnet
 - [x] Calling `__constructor` instead of `initialize` in timelock, since [cap-0058](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0058.md)
 - [x] Since the Horizon API does not have `result_meta_xdr` any longer (two weeks earlier than announced), using `getTransaction` from the `rpc.Server`. Now we use both Horizon API and RPC API. Perhaps, we could switch to RPC completely in the future.
 - [x] Add workflow `testnet.yml` to deploy all the contracts we use, including the old version of `xycloans`. This workflow is only triggered on-demand or once per week, so we don't have to spam the testnet on every commit.

Optimally, it would be great to have a smaller PR, but all these things pulled one another.